### PR TITLE
Adding config endpoint

### DIFF
--- a/lib/txgh/app.rb
+++ b/lib/txgh/app.rb
@@ -35,8 +35,11 @@ module Txgh
 
         status 200
         json data: data
-      rescue => e
+      rescue ConfigNotFoundError => e
         status 404
+        json [{ error: e.message }]
+      rescue => e
+        status 500
         json [{ error: e.message }]
       end
     end

--- a/lib/txgh/errors.rb
+++ b/lib/txgh/errors.rb
@@ -3,4 +3,5 @@ module Txgh
   class TxghInternalError < TxghError; end
 
   class TransifexApiError < StandardError; end
+  class ConfigNotFoundError < StandardError; end
 end

--- a/lib/txgh/key_manager.rb
+++ b/lib/txgh/key_manager.rb
@@ -37,9 +37,13 @@ module Txgh
                 "TX_CONFIG specified a file from git but did not provide a ref."
             end
 
-            Txgh::TxConfig.load(
-              github_repo.api.download(github_repo.name, payload, ref)
-            )
+            begin
+              Txgh::TxConfig.load(
+                github_repo.api.download(github_repo.name, payload, ref)
+              )
+            rescue Octokit::NotFound
+              raise ConfigNotFoundError, "Config file #{payload} not found in #{ref}"
+            end
         end
       end
 

--- a/lib/txgh/tx_branch_resource.rb
+++ b/lib/txgh/tx_branch_resource.rb
@@ -38,6 +38,13 @@ module Txgh
       [project_slug, resource_slug]
     end
 
+    def to_h
+      resource.to_h.merge(
+        project_slug: project_slug,
+        resource_slug: resource_slug
+      )
+    end
+
     private
 
     def slugified_branch

--- a/lib/txgh/tx_config.rb
+++ b/lib/txgh/tx_config.rb
@@ -67,5 +67,9 @@ module Txgh
         end
       end
     end
+
+    def to_h
+      { resources: resources.map(&:to_h), lang_map: lang_map }
+    end
   end
 end

--- a/lib/txgh/tx_resource.rb
+++ b/lib/txgh/tx_resource.rb
@@ -40,5 +40,16 @@ module Txgh
     def slugs
       [project_slug, resource_slug]
     end
+
+    def to_h
+      {
+        project_slug: project_slug,
+        resource_slug: resource_slug,
+        type: type,
+        source_lang: source_lang,
+        source_file: source_file,
+        translation_file: translation_file
+      }
+    end
   end
 end

--- a/lib/txgh/utils.rb
+++ b/lib/txgh/utils.rb
@@ -5,6 +5,7 @@ module Txgh
     end
 
     def absolute_branch(branch)
+      return unless branch
       if branch.include?('tags/')
         branch
       elsif branch.include?('heads/')

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -52,7 +52,22 @@ describe Txgh::Application do
       )
     end
 
-    it 'returns an error response on error' do
+    it "responds with not found when config can't be found" do
+      message = 'Red alert!'
+
+      expect(Txgh::KeyManager).to(
+        receive(:tx_config).and_raise(ConfigNotFoundError, message)
+      )
+
+      get '/config', project_slug: project_name
+      expect(last_response.status).to eq(404)
+      response = JSON.parse(last_response.body)
+      expect(response).to eq([
+        'error' => message
+      ])
+    end
+
+    it 'responds with internal error when an unexpected error occurs' do
       message = 'Red alert!'
 
       expect(Txgh::KeyManager).to(
@@ -60,6 +75,7 @@ describe Txgh::Application do
       )
 
       get '/config', project_slug: project_name
+      expect(last_response.status).to eq(500)
       response = JSON.parse(last_response.body)
       expect(response).to eq([
         'error' => message

--- a/spec/tx_branch_resource_spec.rb
+++ b/spec/tx_branch_resource_spec.rb
@@ -64,5 +64,18 @@ describe TxBranchResource do
         expect(resource.slugs).to eq([project_slug, resource_slug_with_branch])
       end
     end
+
+    describe '#to_h' do
+      it 'converts the resource into a hash' do
+        expect(resource.to_h).to eq(
+          project_slug: project_slug,
+          resource_slug: resource_slug_with_branch,
+          type: 'type',
+          source_lang: 'source_lang',
+          source_file: 'source_file',
+          translation_file: 'translation_file'
+        )
+      end
+    end
   end
 end

--- a/spec/tx_resource_spec.rb
+++ b/spec/tx_resource_spec.rb
@@ -31,4 +31,17 @@ describe TxResource do
       expect(resource.slugs).to eq(%w(project_slug resource_slug))
     end
   end
+
+  describe '#to_h' do
+    it 'converts the resource into a hash' do
+      expect(resource.to_h).to eq(
+        project_slug: 'project_slug',
+        resource_slug: 'resource_slug',
+        type: 'type',
+        source_lang: 'source_lang',
+        source_file: 'source_file',
+        translation_file: 'translation_file'
+      )
+    end
+  end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -25,5 +25,9 @@ describe Utils do
     it 'prefixes heads/ to bare branch names' do
       expect(Utils.absolute_branch('foo')).to eq('heads/foo')
     end
+
+    it 'handles a nil branch' do
+      expect(Utils.absolute_branch(nil)).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
Adds a `/config` endpoint that serves up the tx.config for the given project and branch.

Typical request:

`http://host:port/config?branch=heads%2Fmaster&project_slug=hcp`

Typical response:

``` json
{
   "data": {
      "resources": [{
         "project_slug": "hcp",
         "resource_slug": "enyml",
         "type": "YML",
         "source_lang": "en",
         "source_file": "config/locales/en.yml",
         "translation_file": "config/locales/<lang>.yml"
      }],
      "lang_map": {},
      "branch_slug": "heads_master"
   }
}
```

@lumoslabs/platform
