### PR TITLE
Automatically delete Transifex resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ config/initializers/secret_token.rb
 Gemfile.lock
 config/txgh_config.rb
 .env
+.byebug_history
+

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'puma', '~> 2.15'
 
 group :development, :test do
-  gem 'pry-nav'
+  gem 'pry-byebug'
   gem 'rake'
 end
 

--- a/lib/txgh/github_repo.rb
+++ b/lib/txgh/github_repo.rb
@@ -19,6 +19,22 @@ module Txgh
       branch == 'all'
     end
 
+    def should_process_branch?(candidate)
+      process_all_branches? || (
+        candidate.include?(github_config_branch) || candidate.include?('L10N')
+      )
+    end
+
+    def github_config_branch
+      @github_config_branch = begin
+        if process_all_branches?
+          branch
+        else
+          Utils.absolute_branch(branch || 'master')
+        end
+      end
+    end
+
     def webhook_secret
       config['webhook_secret']
     end

--- a/lib/txgh/github_repo.rb
+++ b/lib/txgh/github_repo.rb
@@ -20,15 +20,15 @@ module Txgh
     end
 
     def should_process_branch?(candidate)
-      process_all_branches? || (
-        candidate.include?(github_config_branch) || candidate.include?('L10N')
-      )
+      process_all_branches? ||
+        candidate.include?(github_config_branch) ||
+        candidate.include?('L10N')
     end
 
     def github_config_branch
-      @github_config_branch = begin
+      @github_config_branch ||= begin
         if process_all_branches?
-          branch
+          'all'
         else
           Utils.absolute_branch(branch || 'master')
         end

--- a/lib/txgh/handlers/github.rb
+++ b/lib/txgh/handlers/github.rb
@@ -1,6 +1,7 @@
 module Txgh
   module Handlers
     module Github
+      autoload :DeleteHandler,  'txgh/handlers/github/delete_handler'
       autoload :PushHandler,    'txgh/handlers/github/push_handler'
       autoload :RequestHandler, 'txgh/handlers/github/request_handler'
     end

--- a/lib/txgh/handlers/github.rb
+++ b/lib/txgh/handlers/github.rb
@@ -2,6 +2,7 @@ module Txgh
   module Handlers
     module Github
       autoload :DeleteHandler,  'txgh/handlers/github/delete_handler'
+      autoload :Handler,        'txgh/handlers/github/handler'
       autoload :PushHandler,    'txgh/handlers/github/push_handler'
       autoload :RequestHandler, 'txgh/handlers/github/request_handler'
     end

--- a/lib/txgh/handlers/github/delete_handler.rb
+++ b/lib/txgh/handlers/github/delete_handler.rb
@@ -57,7 +57,9 @@ module Txgh
 
         def should_handle_request?
           # ref_type can be either 'branch' or 'tag' - we only care about branches
-          payload['ref_type'] == 'branch' && repo.should_process_branch?(branch)
+          payload['ref_type'] == 'branch' &&
+            repo.should_process_branch?(branch) &&
+            project.auto_delete_resources?
         end
 
         def branch

--- a/lib/txgh/handlers/github/delete_handler.rb
+++ b/lib/txgh/handlers/github/delete_handler.rb
@@ -1,0 +1,69 @@
+require 'logger'
+
+module Txgh
+  module Handlers
+    module Github
+      class DeleteHandler
+        include ResponseHelpers
+
+        attr_reader :project, :repo, :payload, :logger
+
+        def initialize(options = {})
+          @project = options.fetch(:project)
+          @repo = options.fetch(:repo)
+          @payload = options.fetch(:payload)
+          @logger = options.fetch(:logger) { Logger.new(STDOUT) }
+        end
+
+        def execute
+          if should_handle_request?
+            if tx_config
+              delete_resources
+              respond_with(200, true)
+            else
+              respond_with_error(
+                404, "Could not find configuration for branch '#{branch}'"
+              )
+            end
+          else
+            respond_with(200, true)
+          end
+        end
+
+        private
+
+        def delete_resources
+          tx_resources.each do |tx_resource|
+            logger.info("Deleting #{tx_resource.resource_slug}")
+            project.api.delete(tx_resource)
+          end
+        end
+
+        def tx_config
+          @tx_config ||= Txgh::KeyManager.tx_config(project, repo, branch)
+        rescue ConfigNotFoundError, TxghError
+          nil
+        end
+
+        def tx_resources
+          @tx_resources ||= tx_config.resources.map do |tx_resource|
+            branch_resource = tx_config.resource(tx_resource.resource_slug, branch)
+
+            if branch_resource && project.api.resource_exists?(branch_resource)
+              branch_resource
+            end
+          end.compact
+        end
+
+        def should_handle_request?
+          # ref_type can be either 'branch' or 'tag' - we only care about branches
+          payload['ref_type'] == 'branch' && repo.should_process_branch?(branch)
+        end
+
+        def branch
+          Utils.absolute_branch(payload['ref'].sub(/^refs\//, ''))
+        end
+      end
+    end
+  end
+end

--- a/lib/txgh/handlers/github/delete_handler.rb
+++ b/lib/txgh/handlers/github/delete_handler.rb
@@ -1,19 +1,7 @@
-require 'logger'
-
 module Txgh
   module Handlers
     module Github
-      class DeleteHandler
-        include ResponseHelpers
-
-        attr_reader :project, :repo, :payload, :logger
-
-        def initialize(options = {})
-          @project = options.fetch(:project)
-          @repo = options.fetch(:repo)
-          @payload = options.fetch(:payload)
-          @logger = options.fetch(:logger) { Logger.new(STDOUT) }
-        end
+      class DeleteHandler < Handler
 
         def execute
           if should_handle_request?
@@ -65,6 +53,7 @@ module Txgh
         def branch
           Utils.absolute_branch(payload['ref'].sub(/^refs\//, ''))
         end
+
       end
     end
   end

--- a/lib/txgh/handlers/github/handler.rb
+++ b/lib/txgh/handlers/github/handler.rb
@@ -1,0 +1,20 @@
+require 'logger'
+
+module Txgh
+  module Handlers
+    module Github
+      class Handler
+        include ResponseHelpers
+
+        attr_reader :project, :repo, :payload, :logger
+
+        def initialize(options = {})
+          @project = options.fetch(:project)
+          @repo = options.fetch(:repo)
+          @payload = options.fetch(:payload)
+          @logger = options.fetch(:logger) { Logger.new(STDOUT) }
+        end
+      end
+    end
+  end
+end

--- a/lib/txgh/handlers/github/push_handler.rb
+++ b/lib/txgh/handlers/github/push_handler.rb
@@ -1,20 +1,9 @@
 require 'base64'
-require 'logger'
 
 module Txgh
   module Handlers
     module Github
-      class PushHandler
-        include ResponseHelpers
-
-        attr_reader :project, :repo, :payload, :logger
-
-        def initialize(options = {})
-          @project = options.fetch(:project)
-          @repo = options.fetch(:repo)
-          @payload = options.fetch(:payload)
-          @logger = options.fetch(:logger) { Logger.new(STDOUT) }
-        end
+      class PushHandler < Handler
 
         def execute
           # Check if the branch in the hook data is the configured branch we want
@@ -112,6 +101,7 @@ module Txgh
         def branch
           @ref ||= payload['ref'].sub(/^refs\//, '')
         end
+
       end
     end
   end

--- a/lib/txgh/handlers/github/request_handler.rb
+++ b/lib/txgh/handlers/github/request_handler.rb
@@ -12,6 +12,8 @@ module Txgh
             case request.env['HTTP_X_GITHUB_EVENT']
               when 'push'
                 handle_push(request, logger)
+              when 'delete'
+                handle_delete(request, logger)
               else
                 handle_unexpected
             end
@@ -21,6 +23,11 @@ module Txgh
 
           def handle_push(request, logger)
             klass = Txgh::Handlers::Github::PushHandler
+            new(request, logger).handle(klass)
+          end
+
+          def handle_delete(request, logger)
+            klass = Txgh::Handlers::Github::DeleteHandler
             new(request, logger).handle(klass)
           end
 
@@ -73,9 +80,7 @@ module Txgh
         end
 
         def github_repo_name
-          owner = "#{payload['repository']['owner']['name']}"
-          repo = "#{payload['repository']['name']}"
-          "#{owner}/#{repo}"
+          payload['repository']['full_name']
         end
 
         def config

--- a/lib/txgh/handlers/transifex/hook_handler.rb
+++ b/lib/txgh/handlers/transifex/hook_handler.rb
@@ -20,14 +20,20 @@ module Txgh
         def execute
           logger.info(resource_slug)
 
-          if tx_resource
-            committer = ResourceCommitter.new(project, repo, logger)
-            committer.commit_resource(tx_resource, branch, language)
+          if tx_config
+            if tx_resource
+              committer = ResourceCommitter.new(project, repo, logger)
+              committer.commit_resource(tx_resource, branch, language)
 
-            respond_with(200, true)
+              respond_with(200, true)
+            else
+              respond_with_error(
+                404, "Could not find resource '#{resource_slug}' in config"
+              )
+            end
           else
             respond_with_error(
-              404, "Could not find configuration for resource '#{resource_slug}'"
+              404, "Could not find configuration for branch '#{branch}'"
             )
           end
         end
@@ -36,6 +42,8 @@ module Txgh
 
         def tx_config
           @tx_config ||= Txgh::KeyManager.tx_config(project, repo, branch)
+        rescue ConfigNotFoundError, TxghError
+          nil
         end
 
         def branch

--- a/lib/txgh/key_manager.rb
+++ b/lib/txgh/key_manager.rb
@@ -82,7 +82,8 @@ module Txgh
                 'api_password' => ENV['TX_PASSWORD'],
                 'push_translations_to' => ENV['TX_PUSH_TRANSLATIONS_TO'],
                 'protected_branches' => ENV['PROTECTED_BRANCHES'],
-                'webhook_secret' => ENV['TX_WEBHOOK_SECRET']
+                'webhook_secret' => ENV['TX_WEBHOOK_SECRET'],
+                'auto_delete_resources' => ENV['AUTO_DELETE_RESOURCES']
               }
             }
           }

--- a/lib/txgh/transifex_api.rb
+++ b/lib/txgh/transifex_api.rb
@@ -63,6 +63,11 @@ module Txgh
       raise_error!(response)
     end
 
+    def delete(tx_resource)
+      url = "#{API_ROOT}/project/#{tx_resource.project_slug}/resource/#{tx_resource.resource_slug}/"
+      connection.delete(url)
+    end
+
     def update_content(tx_resource, content)
       content_io = get_content_io(tx_resource, content)
       payload = { content: content_io }

--- a/lib/txgh/transifex_api.rb
+++ b/lib/txgh/transifex_api.rb
@@ -109,6 +109,13 @@ module Txgh
       JSON.parse(response.body)
     end
 
+    def get_resources(project_slug)
+      url = "#{API_ROOT}/project/#{project_slug}/resources/"
+      response = connection.get(url)
+      raise_error!(response)
+      JSON.parse(response.body)
+    end
+
     def get_languages(project_slug)
       url = "#{API_ROOT}/project/#{project_slug}/languages/"
       response = connection.get(url)

--- a/lib/txgh/transifex_project.rb
+++ b/lib/txgh/transifex_project.rb
@@ -26,6 +26,10 @@ module Txgh
       !(webhook_secret || '').empty?
     end
 
+    def auto_delete_resources?
+      config.fetch('auto_delete_resources', '').downcase == 'true'
+    end
+
     def tx_config_uri
       config['tx_config']
     end

--- a/lib/txgh/transifex_project.rb
+++ b/lib/txgh/transifex_project.rb
@@ -27,7 +27,7 @@ module Txgh
     end
 
     def auto_delete_resources?
-      config.fetch('auto_delete_resources', '').downcase == 'true'
+      (config['auto_delete_resources'] || '').downcase == 'true'
     end
 
     def tx_config_uri

--- a/lib/txgh/tx_branch_resource.rb
+++ b/lib/txgh/tx_branch_resource.rb
@@ -13,15 +13,19 @@ module Txgh
 
     class << self
       def find(tx_config, resource_slug, branch)
+        resource_slug = deslugify(resource_slug, branch)
+        resource = tx_config.resource(resource_slug)
+        new(resource, branch) if resource
+      end
+
+      def deslugify(resource_slug, branch)
         suffix = "-#{Utils.slugify(branch)}"
 
-        resource = if resource_slug.end_with?(suffix)
-          resource_slug_without_suffix = resource_slug.chomp(suffix)
-          tx_config.resource(resource_slug_without_suffix)
+        if resource_slug.end_with?(suffix)
+          resource_slug.chomp(suffix)
+        else
+          resource_slug
         end
-
-        resource ||= tx_config.resource(resource_slug)
-        new(resource, branch) if resource
       end
     end
 

--- a/lib/txgh/tx_resource.rb
+++ b/lib/txgh/tx_resource.rb
@@ -51,5 +51,14 @@ module Txgh
         translation_file: translation_file
       }
     end
+
+    def to_api_h
+      {
+        'slug' => resource_slug,
+        'i18n_type' => type,
+        'source_language_code' => source_lang,
+        'name' => translation_file
+      }
+    end
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -195,7 +195,7 @@ describe Txgh::Hooks do
           receive(:execute).and_return(respond_with(200, true))
         )
 
-        payload = GithubPayloadBuilder.webhook_payload(repo_name, ref)
+        payload = GithubPayloadBuilder.push_payload(repo_name, ref)
 
         sign_with payload.to_json
         header 'X-GitHub-Event', 'push'
@@ -205,7 +205,7 @@ describe Txgh::Hooks do
       end
 
       it 'returns unauthorized if not properly signed' do
-        payload = GithubPayloadBuilder.webhook_payload(repo_name, ref)
+        payload = GithubPayloadBuilder.push_payload(repo_name, ref)
 
         header 'X-GitHub-Event', 'push'
         post '/github', payload.to_json
@@ -221,7 +221,7 @@ describe Txgh::Hooks do
       end
 
       it 'returns internal error on unexpected error' do
-        payload = GithubPayloadBuilder.webhook_payload(repo_name, ref)
+        payload = GithubPayloadBuilder.push_payload(repo_name, ref)
 
         expect(Txgh::KeyManager).to(
           receive(:config_from_repo).and_raise(StandardError)

--- a/spec/github_repo_spec.rb
+++ b/spec/github_repo_spec.rb
@@ -34,4 +34,52 @@ describe GithubRepo do
       end
     end
   end
+
+  describe '#should_process_branch?' do
+    context 'with all branches indicated' do
+      let(:branch) { 'all' }
+
+      it 'returns true if all branches should be processed' do
+        expect(repo.should_process_branch?('heads/foo')).to eq(true)
+      end
+    end
+
+    it 'returns true if the given branch matches the configured one' do
+      expect(repo.should_process_branch?('heads/master')).to eq(true)
+    end
+
+    it "returns false if the given branch doesn't match the configured one" do
+      expect(repo.should_process_branch?('heads/foo')).to eq(false)
+    end
+
+    it 'returns true if the branch contains the special L10N text' do
+      expect(repo.should_process_branch?('heads/L10N_foo')).to eq(true)
+    end
+  end
+
+  describe '#github_config_branch' do
+    context 'with all branches indicated' do
+      let(:branch) { 'all' }
+
+      it "doesn't modify the passed branch, i.e. returns 'all'" do
+        expect(repo.github_config_branch).to eq('all')
+      end
+    end
+
+    context 'with a nil branch' do
+      let(:branch) { nil }
+
+      it 'chooses master by default' do
+        expect(repo.github_config_branch).to eq('heads/master')
+      end
+    end
+
+    context 'with a configured branch' do
+      let(:branch) { 'foobar' }
+
+      it 'correctly prefixes the branch' do
+        expect(repo.github_config_branch).to eq('heads/foobar')
+      end
+    end
+  end
 end

--- a/spec/handlers/github/delete_handler_spec.rb
+++ b/spec/handlers/github/delete_handler_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'helpers/github_payload_builder'
+require 'helpers/standard_txgh_setup'
+
+include Txgh
+include Txgh::Handlers::Github
+
+describe DeleteHandler do
+  include StandardTxghSetup
+
+  let(:handler) do
+    DeleteHandler.new(
+      project: transifex_project,
+      repo: github_repo,
+      payload: payload.to_h,
+      logger: logger
+    )
+  end
+
+  let(:payload) do
+    GithubPayloadBuilder.delete_payload(repo_name, ref)
+  end
+
+  let(:resource_slug_with_branch) do
+    "#{resource_slug}-#{Utils.slugify(ref)}"
+  end
+
+  it 'deletes the correct resource from transifex' do
+    expect(transifex_api).to receive(:resource_exists?).and_return(true)
+    expect(transifex_api).to receive(:delete) do |tx_resource|
+      expect(tx_resource.project_slug).to eq(project_name)
+      expect(tx_resource.resource_slug).to eq(resource_slug_with_branch)
+    end
+
+    handler.execute
+  end
+
+  it 'does not delete non-existent resources' do
+    expect(transifex_api).to receive(:resource_exists?).and_return(false)
+    expect(transifex_api).to_not receive(:delete)
+    handler.execute
+  end
+end

--- a/spec/handlers/github/delete_handler_spec.rb
+++ b/spec/handlers/github/delete_handler_spec.rb
@@ -45,6 +45,15 @@ describe DeleteHandler do
     expect(response.body).to eq(true)
   end
 
+  it 'does not delete resources if auto resource deletions are disabled' do
+    allow(transifex_api).to receive(:resource_exists?).and_return(true)
+    project_config['auto_delete_resources'] = 'false'
+    expect(transifex_api).to_not receive(:delete)
+    response = handler.execute
+    expect(response.status).to eq(200)
+    expect(response.body).to eq(true)
+  end
+
   it "responds with an error if the config can't be found" do
     allow(handler).to receive(:tx_config).and_return(nil)
     response = handler.execute

--- a/spec/handlers/github/delete_handler_spec.rb
+++ b/spec/handlers/github/delete_handler_spec.rb
@@ -32,12 +32,25 @@ describe DeleteHandler do
       expect(tx_resource.resource_slug).to eq(resource_slug_with_branch)
     end
 
-    handler.execute
+    response = handler.execute
+    expect(response.status).to eq(200)
+    expect(response.body).to eq(true)
   end
 
   it 'does not delete non-existent resources' do
     expect(transifex_api).to receive(:resource_exists?).and_return(false)
     expect(transifex_api).to_not receive(:delete)
-    handler.execute
+    response = handler.execute
+    expect(response.status).to eq(200)
+    expect(response.body).to eq(true)
+  end
+
+  it "responds with an error if the config can't be found" do
+    allow(handler).to receive(:tx_config).and_return(nil)
+    response = handler.execute
+    expect(response.status).to eq(404)
+    expect(response.body).to eq([
+      { error: "Could not find configuration for branch '#{ref}'" }
+    ])
   end
 end

--- a/spec/handlers/github/push_handler_spec.rb
+++ b/spec/handlers/github/push_handler_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'helpers/github_payload_builder'
-require 'helpers/nil_logger'
 require 'helpers/standard_txgh_setup'
 
 include Txgh
@@ -19,7 +18,7 @@ describe PushHandler do
   end
 
   let(:payload) do
-    GithubPayloadBuilder.webhook_payload(repo_name, ref)
+    GithubPayloadBuilder.push_payload(repo_name, ref)
   end
 
   let(:modified_files) do

--- a/spec/handlers/transifex/hook_handler_spec.rb
+++ b/spec/handlers/transifex/hook_handler_spec.rb
@@ -42,6 +42,15 @@ describe HookHandler do
     expect(response.body).to eq(true)
   end
 
+  it "responds with an error if the config can't be found" do
+    expect(handler).to receive(:tx_config).and_return(nil)
+    response = handler.execute
+    expect(response.status).to eq(404)
+    expect(response.body).to eq([
+      { error: "Could not find configuration for branch 'heads/#{branch}'" }
+    ])
+  end
+
   context 'with a non-existent resource' do
     let(:requested_resource_slug) { 'foobarbazboo' }
 

--- a/spec/handlers/transifex/hook_handler_spec.rb
+++ b/spec/handlers/transifex/hook_handler_spec.rb
@@ -49,7 +49,7 @@ describe HookHandler do
       response = handler.execute
       expect(response.status).to eq(404)
       expect(response.body).to eq(
-        [{ error: "Could not find configuration for resource '#{requested_resource_slug}'" }]
+        [{ error: "Could not find resource '#{requested_resource_slug}' in config" }]
       )
     end
   end

--- a/spec/helpers/github_payload_builder.rb
+++ b/spec/helpers/github_payload_builder.rb
@@ -2,8 +2,12 @@ require 'json'
 
 class GithubPayloadBuilder
   class << self
-    def webhook_payload(*args)
-      GithubWebhookPayload.new(*args)
+    def push_payload(*args)
+      GithubPushPayload.new(*args)
+    end
+
+    def delete_payload(*args)
+      GithubDeletePayload.new(*args)
     end
   end
 end
@@ -37,7 +41,35 @@ class GithubPayload
   end
 end
 
-class GithubWebhookPayload < GithubPayload
+class GithubDeletePayload < GithubPayload
+  attr_reader :repo, :ref
+
+  def initialize(repo, ref)
+    @repo = repo
+    @ref = ref
+
+    @result = {
+      ref: "refs/#{ref}",
+      ref_type: 'branch',
+      pusher_type: 'user',
+
+      repository: {
+        name: repo.split('/').last,
+        full_name: repo,
+        owner: {
+          login: repo.split('/').first
+        }
+      },
+
+      sender: {
+        login: repo.split('/').first,
+        type: 'User'
+      }
+    }
+  end
+end
+
+class GithubPushPayload < GithubPayload
   attr_reader :repo, :ref, :before, :after
 
   DEFAULT_USER = {

--- a/spec/helpers/standard_txgh_setup.rb
+++ b/spec/helpers/standard_txgh_setup.rb
@@ -22,7 +22,8 @@ module StandardTxghSetup
       'push_translations_to' => repo_name,
       'name' => project_name,
       'tx_config' => "raw://#{tx_config_raw}",
-      'webhook_secret' => 'abc123'
+      'webhook_secret' => 'abc123',
+      'auto_delete_resources' => 'true'
     }
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'pry-nav'
+require 'pry-byebug'
 require 'rake'
 require 'rspec'
 require 'txgh'

--- a/spec/transifex_api_spec.rb
+++ b/spec/transifex_api_spec.rb
@@ -245,6 +245,29 @@ describe TransifexApi do
     end
   end
 
+  describe '#get_resources' do
+    it 'makes a request with the correct parameters' do
+      expect(connection).to receive(:get) do |url, payload|
+        expect(url).to(
+          end_with("project/#{project_name}/resources/")
+        )
+
+        response
+      end
+
+      expect(response).to receive(:status).and_return(200)
+      expect(response).to receive(:body).and_return('{"foo":"bar"}')
+      expect(api.get_resources(project_name)).to eq({ 'foo' => 'bar' })
+    end
+
+    it 'raises an exception if the api responds with an error code' do
+      allow(connection).to receive(:get).and_return(response)
+      allow(response).to receive(:status).and_return(404)
+      allow(response).to receive(:body).and_return('{}')
+      expect { api.get_resources(project_name) }.to raise_error(TransifexApiError)
+    end
+  end
+
   describe '#get_languages' do
     it 'makes a request with the correct parameters' do
       expect(connection).to receive(:get) do |url, payload|

--- a/spec/transifex_api_spec.rb
+++ b/spec/transifex_api_spec.rb
@@ -104,6 +104,18 @@ describe TransifexApi do
     end
   end
 
+  describe '#delete' do
+    it 'deletes the given resource' do
+      expect(connection).to receive(:delete) do |url|
+        expect(url).to(
+          end_with("project/#{project_name}/resource/#{resource_slug}/")
+        )
+      end
+
+      api.delete(resource)
+    end
+  end
+
   describe '#update_content' do
     it 'makes a request with the correct parameters' do
       expect(connection).to receive(:put) do |url, payload|

--- a/spec/transifex_project_spec.rb
+++ b/spec/transifex_project_spec.rb
@@ -20,4 +20,21 @@ describe TransifexProject do
       )
     end
   end
+
+  describe '#auto_delete_resources' do
+    it 'returns false by default' do
+      project_config['auto_delete_resources'] = nil
+      expect(transifex_project.auto_delete_resources?).to eq(false)
+    end
+
+    it 'returns true if configured' do
+      project_config['auto_delete_resources'] = 'true'
+      expect(transifex_project.auto_delete_resources?).to eq(true)
+    end
+
+    it 'handles inconsistent casing' do
+      project_config['auto_delete_resources'] = 'tRuE'
+      expect(transifex_project.auto_delete_resources?).to eq(true)
+    end
+  end
 end

--- a/spec/tx_branch_resource_spec.rb
+++ b/spec/tx_branch_resource_spec.rb
@@ -47,6 +47,18 @@ describe TxBranchResource do
     end
   end
 
+  describe '.deslugify' do
+    it 'removes the branch suffix from the resource slug' do
+      result = TxBranchResource.deslugify(resource_slug_with_branch, branch)
+      expect(result).to eq(resource_slug)
+    end
+
+    it 'hands back the original slug if no suffix' do
+      result = TxBranchResource.deslugify(resource_slug, branch)
+      expect(result).to eq(resource_slug)
+    end
+  end
+
   context 'with a resource' do
     let(:resource) do
       TxBranchResource.new(base_resource, branch)


### PR DESCRIPTION
Currently, resources in Transifex are never deleted, which can lead to a build-up of crusty, unused resources. This PR adds a handler for the Github `delete` event, which gets fired whenever a branch or tag is deleted. Since it's common to delete a branch after merging to master, this functionality should prevent the accumulation of old resources.

@lumoslabs/platform 
