### PR TITLE
Multi-project support

### DIFF
--- a/lib/txgh.rb
+++ b/lib/txgh.rb
@@ -1,4 +1,5 @@
 require 'txgh/errors'
+require 'yaml'
 
 module Txgh
   autoload :Application,          'txgh/app'
@@ -27,6 +28,10 @@ module Txgh
       Txgh::Config::TxManager
     end
 
+    def key_manager
+      Txgh::Config::KeyManager
+    end
+
     def providers
       Txgh::Config::Providers
     end
@@ -36,4 +41,8 @@ module Txgh
   tx_manager.register_provider(providers::FileProvider, Txgh::Config::TxConfig)
   tx_manager.register_provider(providers::GitProvider,  Txgh::Config::TxConfig)
   tx_manager.register_provider(providers::RawProvider,  Txgh::Config::TxConfig)
+
+  # default set of base config providers
+  key_manager.register_provider(providers::FileProvider, YAML)
+  key_manager.register_provider(providers::RawProvider,  YAML)
 end

--- a/lib/txgh/config/key_manager.rb
+++ b/lib/txgh/config/key_manager.rb
@@ -6,6 +6,8 @@ module Txgh
   module Config
     class KeyManager
       class << self
+        include ProviderSupport
+
         def config_from_project(project_name)
           project_config = project_config_for(project_name)
           repo_config = repo_config_for(project_config['push_translations_to'])
@@ -26,34 +28,13 @@ module Txgh
 
         private
 
-        def base_config
-          {
-            'github' => {
-              'repos' => {
-                ENV['TX_PUSH_TRANSLATIONS_TO'] => {
-                  'api_username' => ENV['GITHUB_USERNAME'],
-                  'api_token' => ENV['GITHUB_TOKEN'],
-                  'push_source_to' => ENV['GITHUB_PUSH_SOURCE_TO'],
-                  'branch' => ENV['GITHUB_BRANCH'],
-                  'webhook_secret' => ENV['GITHUB_WEBHOOK_SECRET']
-                }
-              }
-            },
+        def raw_config
+          ENV['TXGH_CONFIG']
+        end
 
-            'transifex' => {
-              'projects' => {
-                ENV['GITHUB_PUSH_SOURCE_TO'] => {
-                  'tx_config' => ENV['TX_CONFIG_PATH'],
-                  'api_username' => ENV['TX_USERNAME'],
-                  'api_password' => ENV['TX_PASSWORD'],
-                  'push_translations_to' => ENV['TX_PUSH_TRANSLATIONS_TO'],
-                  'protected_branches' => ENV['PROTECTED_BRANCHES'],
-                  'webhook_secret' => ENV['TX_WEBHOOK_SECRET'],
-                  'auto_delete_resources' => ENV['AUTO_DELETE_RESOURCES']
-                }
-              }
-            }
-          }
+        def base_config
+          scheme, payload = split_uri(raw_config)
+          provider_for(scheme).load(payload)
         end
 
         def project_config_for(project_name)

--- a/spec/helpers/standard_txgh_setup.rb
+++ b/spec/helpers/standard_txgh_setup.rb
@@ -1,4 +1,5 @@
 require 'helpers/nil_logger'
+require 'yaml'
 
 module StandardTxghSetup
   extend RSpec::SharedContext
@@ -58,7 +59,7 @@ module StandardTxghSetup
 
   before(:each) do
     allow(Txgh::Config::KeyManager).to(
-      receive(:base_config).and_return(base_config)
+      receive(:raw_config) { "raw://#{YAML.dump(base_config)}" }
     )
   end
 

--- a/spec/integration/hooks_spec.rb
+++ b/spec/integration/hooks_spec.rb
@@ -6,6 +6,7 @@ require 'pathname'
 require 'rack/test'
 require 'helpers/integration_setup'
 require 'uri'
+require 'yaml'
 
 include Txgh
 
@@ -65,7 +66,7 @@ describe 'hook integration tests', integration: true do
 
   before(:each) do
     allow(Txgh::Config::KeyManager).to(
-      receive(:base_config).and_return(base_config)
+      receive(:raw_config).and_return("raw://#{YAML.dump(base_config)}")
     )
   end
 


### PR DESCRIPTION
Last one, I promise!

Now that we have all the config loading logic separated out into providers, we should be able to use them to load base config as well as tx config.

@lumoslabs/platform 
