### PR TITLE
Provide a way to skip processing tags

### DIFF
--- a/lib/txgh/github_repo.rb
+++ b/lib/txgh/github_repo.rb
@@ -15,14 +15,24 @@ module Txgh
       config['branch']
     end
 
+    def tag
+      config['tag']
+    end
+
     def process_all_branches?
       branch == 'all'
     end
 
-    def should_process_branch?(candidate)
-      process_all_branches? ||
-        candidate.include?(github_config_branch) ||
-        candidate.include?('L10N')
+    def process_all_tags?
+      tag == 'all'
+    end
+
+    def should_process_ref?(candidate)
+      if Utils.is_tag?(candidate)
+        should_process_tag?(candidate)
+      else
+        should_process_branch?(candidate)
+      end
     end
 
     def github_config_branch
@@ -35,12 +45,36 @@ module Txgh
       end
     end
 
+    def github_config_tag
+      @github_config_tag ||= begin
+        if process_all_tags?
+          'all'
+        else
+          Utils.absolute_branch(tag) if tag
+        end
+      end
+    end
+
     def webhook_secret
       config['webhook_secret']
     end
 
     def webhook_protected?
       !(webhook_secret || '').empty?
+    end
+
+    private
+
+    def should_process_branch?(candidate)
+      process_all_branches? ||
+        candidate.include?(github_config_branch) ||
+        candidate.include?('L10N')
+    end
+
+    def should_process_tag?(candidate)
+      process_all_tags? || (
+        github_config_tag && candidate.include?(github_config_tag)
+      )
     end
   end
 end

--- a/lib/txgh/handlers/github/delete_handler.rb
+++ b/lib/txgh/handlers/github/delete_handler.rb
@@ -51,7 +51,7 @@ module Txgh
         def should_handle_request?
           # ref_type can be either 'branch' or 'tag' - we only care about branches
           payload['ref_type'] == 'branch' &&
-            repo.should_process_branch?(branch) &&
+            repo.should_process_ref?(branch) &&
             project.auto_delete_resources?
         end
 

--- a/lib/txgh/handlers/github/push_handler.rb
+++ b/lib/txgh/handlers/github/push_handler.rb
@@ -10,7 +10,7 @@ module Txgh
           logger.info("request github branch: #{branch}")
           logger.info("config github branch: #{repo.github_config_branch}")
 
-          if repo.should_process_branch?(branch)
+          if repo.should_process_ref?(branch)
             logger.info('found branch in github request')
 
             tx_resources = tx_resources_for(branch)

--- a/lib/txgh/utils.rb
+++ b/lib/txgh/utils.rb
@@ -6,13 +6,17 @@ module Txgh
 
     def absolute_branch(branch)
       return unless branch
-      if branch.include?('tags/')
+      if is_tag?(branch)
         branch
       elsif branch.include?('heads/')
         branch
       else
         "heads/#{branch}"
       end
+    end
+
+    def is_tag?(ref)
+      ref.include?('tags/')
     end
   end
 

--- a/spec/helpers/standard_txgh_setup.rb
+++ b/spec/helpers/standard_txgh_setup.rb
@@ -12,6 +12,7 @@ module StandardTxghSetup
   let(:resource_slug) { 'my_resource' }
   let(:repo_name) { 'my_org/my_repo' }
   let(:branch) { 'master' }
+  let(:tag) { 'all' }
   let(:ref) { 'heads/master' }
   let(:language) { 'ko_KR' }
   let(:translations) { 'translation file contents' }
@@ -34,6 +35,7 @@ module StandardTxghSetup
       'api_token' => 'github_api_token',
       'push_source_to' => project_name,
       'branch' => branch,
+      'tag' => tag,
       'name' => repo_name,
       'webhook_secret' => 'abc123'
     }

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -30,4 +30,15 @@ describe Utils do
       expect(Utils.absolute_branch(nil)).to eq(nil)
     end
   end
+
+  describe '.is_tag?' do
+    it 'returns true if given a tag' do
+      expect(Utils.is_tag?('tags/foo')).to eq(true)
+    end
+
+    it 'returns false if not given a tag' do
+      expect(Utils.is_tag?('heads/foo')).to eq(false)
+      expect(Utils.is_tag?('foo')).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Txgh currently processes tags, which is getting us into a bit of trouble. Catapult creates tags for all releases, including to staging, which uploads resources to Transifex and sends our word count through the roof. Since these release tags are never deleted, the corresponding resources will sit in Transifex forever. This PR provides a way to either process or skip processing tags.

@lumoslabs/platform 
