### PR TITLE
Add streaming response handlers

### DIFF
--- a/lib/txgh/handlers.rb
+++ b/lib/txgh/handlers.rb
@@ -2,6 +2,7 @@ module Txgh
   module Handlers
     autoload :Github,            'txgh/handlers/github'
     autoload :Response,          'txgh/handlers/response'
+    autoload :StreamResponse,    'txgh/handlers/stream_response'
     autoload :TgzStreamResponse, 'txgh/handlers/tgz_stream_response'
     autoload :Transifex,         'txgh/handlers/transifex'
     autoload :Triggers,          'txgh/handlers/triggers'

--- a/lib/txgh/handlers.rb
+++ b/lib/txgh/handlers.rb
@@ -1,8 +1,10 @@
 module Txgh
   module Handlers
-    autoload :Github,    'txgh/handlers/github'
-    autoload :Response,  'txgh/handlers/response'
-    autoload :Transifex, 'txgh/handlers/transifex'
-    autoload :Triggers,  'txgh/handlers/triggers'
+    autoload :Github,            'txgh/handlers/github'
+    autoload :Response,          'txgh/handlers/response'
+    autoload :TgzStreamResponse, 'txgh/handlers/tgz_stream_response'
+    autoload :Transifex,         'txgh/handlers/transifex'
+    autoload :Triggers,          'txgh/handlers/triggers'
+    autoload :ZipStreamResponse, 'txgh/handlers/zip_stream_response'
   end
 end

--- a/lib/txgh/handlers/response.rb
+++ b/lib/txgh/handlers/response.rb
@@ -7,6 +7,10 @@ module Txgh
         @status = status
         @body = body
       end
+
+      def streaming?
+        false
+      end
     end
   end
 end

--- a/lib/txgh/handlers/stream_response.rb
+++ b/lib/txgh/handlers/stream_response.rb
@@ -1,0 +1,35 @@
+require 'mime/types'
+
+module Txgh
+  module Handlers
+    class StreamResponse
+      attr_reader :attachment, :enum
+
+      def initialize(attachment, enum)
+        @attachment = attachment
+        @enum = enum
+      end
+
+      def write_to(stream)
+        raise NotImplementedError,
+          "please implement #{__method__} in derived classes"
+      end
+
+      def file_extension
+        raise NotImplementedError,
+          "please implement #{__method__} in derived classes"
+      end
+
+      def headers
+        @headers ||= {
+          'Content-Disposition' => "attachment; filename=\"#{attachment}#{file_extension}\"",
+          'Content-Type' => MIME::Types.type_for(file_extension).first.content_type
+        }
+      end
+
+      def streaming?
+        true
+      end
+    end
+  end
+end

--- a/lib/txgh/handlers/tgz_stream_response.rb
+++ b/lib/txgh/handlers/tgz_stream_response.rb
@@ -1,0 +1,56 @@
+require 'mime/types'
+require 'rubygems/package'
+require 'stringio'
+require 'zlib'
+
+module Txgh
+  module Handlers
+    class TgzStreamResponse
+      PERMISSIONS = 0644
+
+      attr_reader :attachment, :enum
+
+      def initialize(attachment, enum)
+        @attachment = attachment
+        @enum = enum
+      end
+
+      def write_to(stream)
+        Zlib::GzipWriter.wrap(stream) do |gz|
+          pipe = StringIO.new('', 'wb')
+          tar = Gem::Package::TarWriter.new(pipe)
+
+          enum.each do |file_name, contents|
+            tar.add_file(file_name, PERMISSIONS) do |f|
+              f.write(contents)
+            end
+
+            flush(tar, pipe, gz)
+            stream.flush
+          end
+
+          flush(tar, pipe, gz)
+        end
+      end
+
+      def streaming?
+        true
+      end
+
+      def headers
+        @headers ||= {
+          'Content-Disposition' => "attachment; filename=\"#{attachment}.tgz\"",
+          'Content-Type' => MIME::Types.type_for('.tgz').first.content_type
+        }
+      end
+
+      private
+
+      def flush(tar, pipe, gz)
+        tar.flush
+        gz.write(pipe.string)
+        pipe.reopen('')
+      end
+    end
+  end
+end

--- a/lib/txgh/handlers/tgz_stream_response.rb
+++ b/lib/txgh/handlers/tgz_stream_response.rb
@@ -1,19 +1,11 @@
-require 'mime/types'
 require 'rubygems/package'
 require 'stringio'
 require 'zlib'
 
 module Txgh
   module Handlers
-    class TgzStreamResponse
+    class TgzStreamResponse < StreamResponse
       PERMISSIONS = 0644
-
-      attr_reader :attachment, :enum
-
-      def initialize(attachment, enum)
-        @attachment = attachment
-        @enum = enum
-      end
 
       def write_to(stream)
         Zlib::GzipWriter.wrap(stream) do |gz|
@@ -33,15 +25,8 @@ module Txgh
         end
       end
 
-      def streaming?
-        true
-      end
-
-      def headers
-        @headers ||= {
-          'Content-Disposition' => "attachment; filename=\"#{attachment}.tgz\"",
-          'Content-Type' => MIME::Types.type_for('.tgz').first.content_type
-        }
+      def file_extension
+        '.tgz'
       end
 
       private

--- a/lib/txgh/handlers/zip_stream_response.rb
+++ b/lib/txgh/handlers/zip_stream_response.rb
@@ -1,15 +1,8 @@
-require 'mime/types'
 require 'zipline'
 
 module Txgh
   module Handlers
-    class ZipStreamResponse
-      attr_reader :attachment, :enum
-
-      def initialize(attachment, enum)
-        @attachment = attachment
-        @enum = enum
-      end
+    class ZipStreamResponse < StreamResponse
 
       def write_to(stream)
         Zipline::OutputStream.open(stream) do |zipfile|
@@ -20,15 +13,8 @@ module Txgh
         end
       end
 
-      def headers
-        @headers ||= {
-          'Content-Disposition' => "attachment; filename=\"#{attachment}.zip\"",
-          'Content-Type' => MIME::Types.type_for('.zip').first.content_type
-        }
-      end
-
-      def streaming?
-        true
+      def file_extension
+        '.zip'
       end
     end
   end

--- a/lib/txgh/handlers/zip_stream_response.rb
+++ b/lib/txgh/handlers/zip_stream_response.rb
@@ -1,0 +1,35 @@
+require 'mime/types'
+require 'zipline'
+
+module Txgh
+  module Handlers
+    class ZipStreamResponse
+      attr_reader :attachment, :enum
+
+      def initialize(attachment, enum)
+        @attachment = attachment
+        @enum = enum
+      end
+
+      def write_to(stream)
+        Zipline::OutputStream.open(stream) do |zipfile|
+          enum.each do |file_name, contents|
+            zipfile.put_next_entry(file_name, contents.bytesize)
+            zipfile << contents
+          end
+        end
+      end
+
+      def headers
+        @headers ||= {
+          'Content-Disposition' => "attachment; filename=\"#{attachment}.zip\"",
+          'Content-Type' => MIME::Types.type_for('.zip').first.content_type
+        }
+      end
+
+      def streaming?
+        true
+      end
+    end
+  end
+end

--- a/spec/handlers/tgz_stream_response_spec.rb
+++ b/spec/handlers/tgz_stream_response_spec.rb
@@ -1,0 +1,59 @@
+require 'rubygems/package'
+require 'spec_helper'
+require 'stringio'
+require 'zlib'
+
+include Txgh::Handlers
+
+describe TgzStreamResponse do
+  def read_tgz_from(io)
+    contents = {}
+
+    Zlib::GzipReader.wrap(io) do |gz|
+      tar = Gem::Package::TarReader.new(gz)
+      tar.each do |entry|
+        contents[entry.full_name] = entry.read
+      end
+    end
+
+    contents
+  end
+
+  let(:attachment) { 'abc123' }
+
+  let(:enum) do
+    {
+      'first_file.yml' => "first\nfile\ncontents\n",
+      'second_file.yml' => "wowowow\nanother file!\n"
+    }
+  end
+
+  let(:response) do
+    TgzStreamResponse.new(attachment, enum)
+  end
+
+  describe '#write_to' do
+    it 'writes a gzipped tar file with the correct entries to the stream' do
+      io = StringIO.new('', 'wb')
+      response.write_to(io)
+      io = io.reopen(io.string, 'rb')
+      contents = read_tgz_from(io)
+      expect(contents).to eq(enum)
+    end
+  end
+
+  describe '#headers' do
+    it 'includes the correct content type and disposition headers' do
+      expect(response.headers).to eq({
+        'Content-Disposition' => "attachment; filename=\"#{attachment}.tgz\"",
+        'Content-Type' => 'application/x-gtar'
+      })
+    end
+  end
+
+  describe '#streaming?' do
+    it 'returns true' do
+      expect(response).to be_streaming
+    end
+  end
+end

--- a/spec/handlers/zip_stream_response_spec.rb
+++ b/spec/handlers/zip_stream_response_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'tempfile'
+
+include Txgh::Handlers
+
+describe ZipStreamResponse do
+  def read_zip_from(file)
+    contents = {}
+
+    Zip::File.open(file) do |zipfile|
+      zipfile.each do |entry|
+        contents[entry.name] = entry.get_input_stream.read
+      end
+    end
+
+    contents
+  end
+
+  let(:attachment) { 'abc123' }
+
+  let(:enum) do
+    {
+      'first_file.yml' => "first\nfile\ncontents\n",
+      'second_file.yml' => "wowowow\nanother file!\n"
+    }
+  end
+
+  let(:response) do
+    ZipStreamResponse.new(attachment, enum)
+  end
+
+  describe '#write_to' do
+    it 'writes a zip file with the correct entries to the stream' do
+      # this does NOT WORK with a StringIO - zip contents MUST be written to a file
+      io = Tempfile.new('testzip')
+      response.write_to(io)
+      contents = read_zip_from(io.path)
+      expect(contents).to eq(enum)
+      io.close
+      io.unlink
+    end
+  end
+
+  describe '#headers' do
+    it 'includes the correct content type and disposition headers' do
+      expect(response.headers).to eq({
+        'Content-Disposition' => "attachment; filename=\"#{attachment}.zip\"",
+        'Content-Type' => 'application/zip'
+      })
+    end
+  end
+
+  describe '#streaming?' do
+    it 'returns true' do
+      expect(response).to be_streaming
+    end
+  end
+end

--- a/txgh.gemspec
+++ b/txgh.gemspec
@@ -17,10 +17,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '~> 0.9'
   s.add_dependency 'faraday_middleware', '~> 0.10'
   s.add_dependency 'json', '~> 1.8'
+  s.add_dependency 'mime-types', '~> 2.0'
   s.add_dependency 'octokit', '~> 4.2'
   s.add_dependency 'parseconfig', '~> 1.0'
   s.add_dependency 'sinatra', '~> 1.4'
   s.add_dependency 'sinatra-contrib', '~> 1.4'
+  s.add_dependency 'zipline', '~> 0.0'
 
   s.require_path = 'lib'
   s.files = Dir['{lib,spec}/**/*', 'README.md', 'txgh.gemspec']


### PR DESCRIPTION
In preparation for adding resource download capabilities, this PR adds two classes capable of streaming .zip and .tgz files.

@lumoslabs/platform 

This PR is part of a larger effort to add download functionality to txgh. See [this issue](https://github.com/lumoslabs/txgh/issues/17) for details.
