### PR TITLE
Adding github ping handler

### DIFF
--- a/lib/txgh/handlers/github.rb
+++ b/lib/txgh/handlers/github.rb
@@ -3,6 +3,7 @@ module Txgh
     module Github
       autoload :DeleteHandler,  'txgh/handlers/github/delete_handler'
       autoload :Handler,        'txgh/handlers/github/handler'
+      autoload :PingHandler,    'txgh/handlers/github/ping_handler'
       autoload :PushHandler,    'txgh/handlers/github/push_handler'
       autoload :RequestHandler, 'txgh/handlers/github/request_handler'
     end

--- a/lib/txgh/handlers/github/ping_handler.rb
+++ b/lib/txgh/handlers/github/ping_handler.rb
@@ -1,0 +1,18 @@
+module Txgh
+  module Handlers
+    module Github
+      # Handles github's ping event, which is a test event fired whenever a new
+      # webhook is set up.
+      class PingHandler
+        include ResponseHelpers
+
+        def initialize(options = {})
+        end
+
+        def execute
+          respond_with(200, {})
+        end
+      end
+    end
+  end
+end

--- a/lib/txgh/handlers/github/request_handler.rb
+++ b/lib/txgh/handlers/github/request_handler.rb
@@ -14,6 +14,8 @@ module Txgh
                 handle_push(request, logger)
               when 'delete'
                 handle_delete(request, logger)
+              when 'ping'
+                handle_ping(request, logger)
               else
                 handle_unexpected
             end
@@ -28,6 +30,11 @@ module Txgh
 
           def handle_delete(request, logger)
             klass = Txgh::Handlers::Github::DeleteHandler
+            new(request, logger).handle(klass)
+          end
+
+          def handle_ping(request, logger)
+            klass = Txgh::Handlers::Github::PingHandler
             new(request, logger).handle(klass)
           end
 

--- a/lib/txgh/response_helpers.rb
+++ b/lib/txgh/response_helpers.rb
@@ -6,8 +6,8 @@ module Txgh
       Txgh::Handlers::Response.new(status, body, e)
     end
 
-    def respond_with_success(status, body)
-      respond_with(status, data(body))
+    def respond_with_success(body)
+      respond_with(200, data(body))
     end
 
     def respond_with_error(status, message, e = nil)

--- a/lib/txgh/response_helpers.rb
+++ b/lib/txgh/response_helpers.rb
@@ -6,10 +6,6 @@ module Txgh
       Txgh::Handlers::Response.new(status, body, e)
     end
 
-    def respond_with_success(body)
-      respond_with(200, data(body))
-    end
-
     def respond_with_error(status, message, e = nil)
       respond_with(status, error(message), e)
     end

--- a/spec/handlers/github/ping_handler_spec.rb
+++ b/spec/handlers/github/ping_handler_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+include Txgh
+include Txgh::Handlers::Github
+
+describe PingHandler do
+  let(:handler) do
+    PingHandler.new
+  end
+
+  it 'responds with a 200 success' do
+    response = handler.execute
+    expect(response.status).to eq(200)
+    expect(response.body).to eq({})
+  end
+end


### PR DESCRIPTION
When you set up a new webhook, Github will send you a "ping" test event. Txgh doesn't handle this event, so right off the bat it looks like the webhook fails. This PR adds a really simple ping handler that responds with a 200 instead of a 404.

@lumoslabs/platform 
