### PR TITLE
Use list of supported locales

### DIFF
--- a/lib/txgh/handlers/download_handler.rb
+++ b/lib/txgh/handlers/download_handler.rb
@@ -54,7 +54,10 @@ module Txgh
       end
 
       def execute
-        downloader = ResourceDownloader.new(project, repo, params['branch'])
+        downloader = ResourceDownloader.new(
+          project, repo, params['branch'], languages: project.languages
+        )
+
         response_class.new(attachment, downloader.each)
       end
 

--- a/lib/txgh/handlers/transifex/hook_handler.rb
+++ b/lib/txgh/handlers/transifex/hook_handler.rb
@@ -20,21 +20,25 @@ module Txgh
         def execute
           logger.info(resource_slug)
 
-          if tx_config
-            if tx_resource
-              committer = ResourceCommitter.new(project, repo, logger)
-              committer.commit_resource(tx_resource, branch, language)
+          if supported_language?
+            if tx_config
+              if tx_resource
+                committer = ResourceCommitter.new(project, repo, logger)
+                committer.commit_resource(tx_resource, branch, language)
 
-              respond_with(200, true)
+                respond_with(200, true)
+              else
+                respond_with_error(
+                  404, "Could not find resource '#{resource_slug}' in config"
+                )
+              end
             else
               respond_with_error(
-                404, "Could not find resource '#{resource_slug}' in config"
+                404, "Could not find configuration for branch '#{branch}'"
               )
             end
           else
-            respond_with_error(
-              404, "Could not find configuration for branch '#{branch}'"
-            )
+            respond_with(304, true)
           end
         end
 
@@ -70,6 +74,10 @@ module Txgh
 
         def process_all_branches?
           repo.process_all_branches?
+        end
+
+        def supported_language?
+          project.supported_language?(language)
         end
       end
     end

--- a/lib/txgh/handlers/triggers/pull_handler.rb
+++ b/lib/txgh/handlers/triggers/pull_handler.rb
@@ -5,6 +5,8 @@ module Txgh
 
         def execute
           languages.each do |language|
+            next unless project.supported_language?(language['language_code'])
+
             committer.commit_resource(
               branch_resource, branch, language['language_code']
             )

--- a/lib/txgh/transifex_project.rb
+++ b/lib/txgh/transifex_project.rb
@@ -33,5 +33,13 @@ module Txgh
     def tx_config_uri
       config['tx_config']
     end
+
+    def languages
+      config.fetch('languages', [])
+    end
+
+    def supported_language?(language)
+      languages.include?(language)
+    end
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -310,6 +310,7 @@ describe Txgh::Triggers do
     it 'updates translations (in all locales) in the expected repo' do
       committer = double(:committer)
       languages = [{ 'language_code' => 'pt' }, { 'language_code' => 'ja' }]
+      project_config['languages'] = %w(pt ja)
       expect(Txgh::ResourceCommitter).to receive(:new).and_return(committer)
       expect(Txgh::TransifexApi).to receive(:new).and_return(transifex_api)
       expect(transifex_api).to receive(:get_languages).and_return(languages)

--- a/spec/handlers/download_handler_spec.rb
+++ b/spec/handlers/download_handler_spec.rb
@@ -77,5 +77,15 @@ describe DownloadHandler do
         expect(handler.execute).to be_a(TgzStreamResponse)
       end
     end
+
+    context 'with a set of languages' do
+      let(:supported_languages) { %w(is fr) }
+
+      it "downloads translations for the project's supported languages" do
+        allow(transifex_api).to receive(:download)
+        files = handler.execute.enum.to_a.map(&:first)
+        expect(files).to eq(%w(translations/is/sample.yml translations/fr/sample.yml))
+      end
+    end
   end
 end

--- a/spec/handlers/transifex/hook_handler_spec.rb
+++ b/spec/handlers/transifex/hook_handler_spec.rb
@@ -112,4 +112,17 @@ describe HookHandler do
       expect(response.body).to eq(true)
     end
   end
+
+  context 'with an unsupported language' do
+    let(:language) { 'pt' }
+    let(:supported_languages) { ['ja'] }
+
+    it "doesn't make a commit" do
+      expect(github_api).to_not receive(:commit)
+
+      response = handler.execute
+      expect(response.status).to eq(304)
+      expect(response.body).to eq(true)
+    end
+  end
 end

--- a/spec/helpers/standard_txgh_setup.rb
+++ b/spec/helpers/standard_txgh_setup.rb
@@ -15,6 +15,7 @@ module StandardTxghSetup
   let(:tag) { 'all' }
   let(:ref) { 'heads/master' }
   let(:language) { 'ko_KR' }
+  let(:supported_languages) { [language] }
   let(:translations) { 'translation file contents' }
   let(:diff_point) { nil }
 
@@ -26,7 +27,8 @@ module StandardTxghSetup
       'name' => project_name,
       'tx_config' => "raw://#{tx_config_raw}",
       'webhook_secret' => 'abc123',
-      'auto_delete_resources' => 'true'
+      'auto_delete_resources' => 'true',
+      'languages' => supported_languages
     }
   end
 

--- a/spec/integration/hooks_spec.rb
+++ b/spec/integration/hooks_spec.rb
@@ -45,7 +45,8 @@ describe 'hook integration tests', integration: true do
             'api_username' => 'txgh.bot',
             'api_password' => '2aqFGW99fPRKWvXBPjbrxkdiR',
             'push_translations_to' => 'txgh-bot/txgh-test-resources',
-            'webhook_secret' => 'fce95b1748fd638c22174d34200f10cf'
+            'webhook_secret' => 'fce95b1748fd638c22174d34200f10cf',
+            'languages' => ['el_GR']
           }
         }
       }


### PR DESCRIPTION
Only commit/download translations for languages in a configured list of supported languages. This is to support the use case where a language is available for translation in Transifex, but is not ready to be shipped out yet.

@lumoslabs/platform @bzatsman 
