### PR TITLE
Annotate commits on github with translation statuses

### DIFF
--- a/lib/txgh.rb
+++ b/lib/txgh.rb
@@ -10,6 +10,7 @@ module Txgh
   autoload :GithubApi,             'txgh/github_api'
   autoload :GithubRepo,            'txgh/github_repo'
   autoload :GithubRequestAuth,     'txgh/github_request_auth'
+  autoload :GithubStatus,          'txgh/github_status'
   autoload :Handlers,              'txgh/handlers'
   autoload :Hooks,                 'txgh/app'
   autoload :MergeCalculator,       'txgh/merge_calculator'

--- a/lib/txgh.rb
+++ b/lib/txgh.rb
@@ -7,6 +7,7 @@ module Txgh
   autoload :Config,                'txgh/config'
   autoload :DiffCalculator,        'txgh/diff_calculator'
   autoload :EmptyResourceContents, 'txgh/empty_resource_contents'
+  autoload :Events,                'txgh/events'
   autoload :GithubApi,             'txgh/github_api'
   autoload :GithubRepo,            'txgh/github_repo'
   autoload :GithubRequestAuth,     'txgh/github_request_auth'

--- a/lib/txgh.rb
+++ b/lib/txgh.rb
@@ -42,6 +42,18 @@ module Txgh
     def providers
       Txgh::Config::Providers
     end
+
+    def events
+      @events ||= Events.new
+    end
+
+    def update_status_callback(options)
+      project = options.fetch(:project)
+      repo = options.fetch(:repo)
+      resource = options.fetch(:resource)
+
+      GithubStatus.new(project, repo, resource).update(options.fetch(:sha))
+    end
   end
 
   # default set of tx config providers
@@ -52,4 +64,12 @@ module Txgh
   # default set of base config providers
   key_manager.register_provider(providers::FileProvider, YAML)
   key_manager.register_provider(providers::RawProvider,  YAML)
+
+  events.subscribe('transifex.resource.updated') do |options|
+    update_status_callback(options)
+  end
+
+  events.subscribe('github.resource.committed') do |options|
+    update_status_callback(options)
+  end
 end

--- a/lib/txgh/events.rb
+++ b/lib/txgh/events.rb
@@ -1,0 +1,35 @@
+module Txgh
+  class Events
+    ERROR_CHANNEL = 'errors'
+
+    attr_reader :channel_hash
+
+    def initialize
+      @channel_hash = Hash.new { |h, k| h[k] = [] }
+    end
+
+    def subscribe(channel, &block)
+      channel_hash[channel] << block
+    end
+
+    def publish(channel, options = {})
+      channel_hash.fetch(channel, []).each do |callback|
+        callback.call(options)
+      end
+    rescue => e
+      publish_error(e)
+    end
+
+    def channels
+      channel_hash.keys
+    end
+
+    private
+
+    def publish_error(e)
+      # if nobody has subscribed to error events, raise original error
+      callbacks = channel_hash.fetch(ERROR_CHANNEL) { raise e }
+      callbacks.each { |callback| callback.call(e) }
+    end
+  end
+end

--- a/lib/txgh/github_api.rb
+++ b/lib/txgh/github_api.rb
@@ -79,5 +79,9 @@ module Txgh
       end
     end
 
+    def create_status(repo, sha, state, options = {})
+      client.create_status(repo, sha, state, options)
+    end
+
   end
 end

--- a/lib/txgh/github_status.rb
+++ b/lib/txgh/github_status.rb
@@ -35,6 +35,8 @@ module Txgh
       )
     end
 
+    private
+
     def context
       CONTEXT
     end
@@ -62,8 +64,6 @@ module Txgh
         DESCRIPTION_TEMPLATE % stat_totals
       end
     end
-
-    private
 
     def all_complete?
       stats.all? do |locale, details|

--- a/lib/txgh/github_status.rb
+++ b/lib/txgh/github_status.rb
@@ -1,0 +1,87 @@
+module Txgh
+  class GithubStatus
+    class State
+      PENDING = 'pending'
+      SUCCESS = 'success'
+      ERROR   = 'error'
+      FAILURE = 'failure'
+
+      class << self
+        def pending; PENDING; end
+        def success; SUCCESS; end
+        def error; ERROR; end
+        def failure; failure; end
+      end
+    end
+
+    ALL_COMPLETE_DESCRIPTION = "Translations complete!"
+    TARGET_URL_TEMPLATE = "https://www.transifex.com/%{organization}/%{project_slug}/%{resource_slug}/"
+    DESCRIPTION_TEMPLATE = "%{complete}/%{total} translations complete."
+    CONTEXT = 'continuous-localization/txgh'
+
+    attr_reader :project, :repo, :tx_resource
+
+    def initialize(project, repo, tx_resource)
+      @project = project
+      @repo = repo
+      @tx_resource = tx_resource
+    end
+
+    def update(sha)
+      repo.api.create_status(
+        repo.name, sha, state, {
+          context: context, target_url: target_url, description: description
+        }
+      )
+    end
+
+    def context
+      CONTEXT
+    end
+
+    def target_url
+      TARGET_URL_TEMPLATE % {
+        organization: project.organization,
+        project_slug: tx_resource.project_slug,
+        resource_slug: tx_resource.resource_slug
+      }
+    end
+
+    def state
+      if all_complete?
+        State.success
+      else
+        State.pending
+      end
+    end
+
+    def description
+      if all_complete?
+        ALL_COMPLETE_DESCRIPTION
+      else
+        DESCRIPTION_TEMPLATE % stat_totals
+      end
+    end
+
+    private
+
+    def all_complete?
+      stats.all? do |locale, details|
+        details['completed'] == '100%'
+      end
+    end
+
+    def stat_totals
+      @stat_totals ||= { complete: 0, total: 0 }.tap do |counts|
+        stats.each_pair do |locale, details|
+          counts[:total] += details['translated_entities'] + details['untranslated_entities']
+          counts[:complete] += details['translated_entities']
+        end
+      end
+    end
+
+    def stats
+      @stats ||= project.api.get_stats(*tx_resource.slugs)
+    end
+  end
+end

--- a/lib/txgh/resource_committer.rb
+++ b/lib/txgh/resource_committer.rb
@@ -16,11 +16,24 @@ module Txgh
 
         if translations
           repo.api.commit(repo.name, branch, { file_name => translations })
+          fire_event_for(tx_resource, branch, language)
         end
       end
     end
 
     private
+
+    def fire_event_for(tx_resource, branch, language)
+      head = repo.api.get_ref(repo.name, branch)
+      sha = head[:object][:sha]
+
+      Txgh.events.publish(
+        'github.resource.committed', {
+          project: project, repo: repo, resource: tx_resource, sha: sha,
+          language: language
+        }
+      )
+    end
 
     def download(tx_resource, branch, language)
       downloader = ResourceDownloader.new(

--- a/lib/txgh/resource_updater.rb
+++ b/lib/txgh/resource_updater.rb
@@ -31,11 +31,21 @@ module Txgh
           else
             upload_whole(tx_resource, file, categories)
           end
+
+          fire_event_for(tx_resource, commit_sha)
         end
       end
     end
 
     private
+
+    def fire_event_for(tx_resource, commit_sha)
+      Txgh.events.publish(
+        'transifex.resource.updated', {
+          project: project, repo: repo, resource: tx_resource, sha: commit_sha
+        }
+      )
+    end
 
     def upload_whole(tx_resource, file, categories)
       content = contents_of(file['sha'])

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+include Txgh
+
+describe Events do
+  let(:events) { Events.new }
+
+  describe '#subscribe and #channels' do
+    it "adds a channel if it doesn't already exist" do
+      expect(events.channels).to be_empty
+      events.subscribe('foo.bar')
+      expect(events.channels).to eq(['foo.bar'])
+    end
+
+    it 'adds the proc to the list of callbacks for the channel' do
+      events.subscribe('foo.bar') { 'baz' }
+      expect(events.channel_hash['foo.bar'].first.call).to eq('baz')
+    end
+  end
+
+  describe '#publish' do
+    it 'notifies all subscribers' do
+      received = []
+      events.subscribe('foo.bar') { |arg| received << "foo.bar #{arg}" }
+      events.subscribe('foo.bar') { |arg| received << "foo.bar2 #{arg}" }
+      events.publish('foo.bar', 'baz')
+      expect(received).to eq([
+        'foo.bar baz', 'foo.bar2 baz'
+      ])
+    end
+
+    it 'publishes errors through a special errors channel' do
+      errors = []
+      events.subscribe('errors') { |e| errors << e }
+      events.subscribe('foo.bar') { raise 'jelly beans' }
+      expect { events.publish('foo.bar') }.to_not raise_error
+      expect(errors.first.message).to eq('jelly beans')
+    end
+
+    it 'raises errors if there are no error subscribers' do
+      events.subscribe('foo.bar') { raise 'jelly beans' }
+      expect { events.publish('foo.bar') }.to raise_error('jelly beans')
+    end
+  end
+end

--- a/spec/github_status_spec.rb
+++ b/spec/github_status_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'helpers/standard_txgh_setup'
+
+include Txgh
+
+describe GithubStatus do
+  include StandardTxghSetup
+
+  describe '#update' do
+    let(:status) { GithubStatus.new(transifex_project, github_repo, resource) }
+    let(:resource) { tx_config.resource(resource_slug) }
+    let(:sha) { 'abc123shashasha' }
+
+    let(:stats) do
+      supported_languages.each_with_object({}) do |language, ret|
+        ret[language] = {
+          'translated_entities' => 10, 'untranslated_entities' => 0,
+          'completed' => '100%'
+        }
+      end
+    end
+
+    before(:each) do
+      allow(transifex_api).to receive(:get_stats).and_return(stats)
+    end
+
+    context 'with all resources at 100%' do
+      it 'reports status as success' do
+        expect(github_api).to receive(:create_status) do |repo, commit_sha, state, options|
+          expect(repo).to eq(repo_name)
+          expect(commit_sha).to eq(sha)
+          expect(state).to eq(GithubStatus::State.success)
+          expect(options[:description]).to eq('Translations complete!')
+          expect(options[:context]).to eq('continuous-localization/txgh')
+          expect(options[:target_url]).to eq(
+            "https://www.transifex.com/#{organization}/#{project_name}/#{resource_slug}/"
+          )
+        end
+
+        status.update(sha)
+      end
+    end
+
+    context 'with one language at less than 100%' do
+      let(:stats) do
+        {
+          'pt' => {
+            'translated_entities' => 10, 'untranslated_entities' => 0,
+            'completed' => '100%'
+          },
+          'ja' => {
+            'translated_entities' => 5, 'untranslated_entities' => 5,
+            'completed' => '50%'
+          }
+        }
+      end
+
+      it 'reports status as pending' do
+        expect(github_api).to receive(:create_status) do |repo, commit_sha, state, options|
+          expect(state).to eq(GithubStatus::State.pending)
+          expect(options[:description]).to eq('15/20 translations complete.')
+        end
+
+        status.update(sha)
+      end
+    end
+  end
+end

--- a/spec/handlers/transifex/hook_handler_spec.rb
+++ b/spec/handlers/transifex/hook_handler_spec.rb
@@ -31,6 +31,10 @@ describe HookHandler do
     allow(downloader).to(receive(:first)).and_return([
       "translations/#{language}/sample.yml", translations
     ])
+
+    allow(github_api).to receive(:get_ref).and_return(
+      object: { sha: '123abcshashasha' }
+    )
   end
 
   it 'downloads translations and pushes them to the correct branch (head)' do

--- a/spec/helpers/standard_txgh_setup.rb
+++ b/spec/helpers/standard_txgh_setup.rb
@@ -18,6 +18,7 @@ module StandardTxghSetup
   let(:supported_languages) { [language] }
   let(:translations) { 'translation file contents' }
   let(:diff_point) { nil }
+  let(:organization) { 'myorg' }
 
   let(:project_config) do
     {
@@ -28,7 +29,8 @@ module StandardTxghSetup
       'tx_config' => "raw://#{tx_config_raw}",
       'webhook_secret' => 'abc123',
       'auto_delete_resources' => 'true',
-      'languages' => supported_languages
+      'languages' => supported_languages,
+      'organization' => organization
     }
   end
 

--- a/spec/helpers/test_events.rb
+++ b/spec/helpers/test_events.rb
@@ -1,0 +1,12 @@
+class TestEvents < Txgh::Events
+  attr_reader :published
+
+  def initialize
+    @published = []
+    super
+  end
+
+  def publish(channel, options = {})
+    published << { channel: channel, options: options }
+  end
+end

--- a/spec/integration/cassettes/transifex_hook_endpoint.yml
+++ b/spec/integration/cassettes/transifex_hook_endpoint.yml
@@ -28,9 +28,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 12 Feb 2016 19:48:51 GMT
+      - Fri, 29 Apr 2016 16:06:38 GMT
       Expires:
-      - Fri, 12 Feb 2016 19:48:51 GMT
+      - Fri, 29 Apr 2016 16:06:38 GMT
       Transfer-Encoding:
       - chunked
       Content-Language:
@@ -42,7 +42,7 @@ http_interactions:
       Set-Cookie:
       - X-Mapping-fjhppofk=D7F0B90A7FEFB2573FEF4C177EEBE6A8; path=/
       Last-Modified:
-      - Fri, 12 Feb 2016 19:48:51 GMT
+      - Fri, 29 Apr 2016 16:06:38 GMT
       X-Frame-Options:
       - SAMEORIGIN
     body:
@@ -63,7 +63,170 @@ http_interactions:
         \\\"Eight\\\"\\nmsgstr \\\"\\\"\\n\\nmsgid \\\"Nine\\\"\\nmsgstr \\\"\\\"\\n\\nmsgid
         \\\"Ten\\\"\\nmsgstr \\\"\\\"\\n\", \n    \"mimetype\": \"text/x-po\"\n}"
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:48:52 GMT
+  recorded_at: Fri, 29 Apr 2016 16:06:41 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 29 Apr 2016 16:06:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4988'
+      X-Ratelimit-Reset:
+      - '1461949570'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"a5fe675407899fa4460005cce07b9fe2"
+      Last-Modified:
+      - Mon, 11 Jan 2016 23:45:43 GMT
+      X-Poll-Interval:
+      - '300'
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - d0b3c2c33a23690498aa8e70a435a259
+      X-Github-Request-Id:
+      - 438EEBFC:76D2:F87C5CA:57238694
+    body:
+      encoding: UTF-8
+      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"f3edb21f027b70974750649ba29b0090e410ecde","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f3edb21f027b70974750649ba29b0090e410ecde"}}'
+    http_version: 
+  recorded_at: Fri, 29 Apr 2016 16:06:49 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f3edb21f027b70974750649ba29b0090e410ecde
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 29 Apr 2016 16:06:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4987'
+      X-Ratelimit-Reset:
+      - '1461949570'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"825a857c42f7c79a3d43dfabbf7bd1b4"
+      Last-Modified:
+      - Wed, 27 Apr 2016 17:33:49 GMT
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - a7f8a126c9ed3f1c4715a34c0ddc7290
+      X-Github-Request-Id:
+      - 438EEBFC:76D4:1CED3E16:57238699
+    body:
+      encoding: UTF-8
+      string: '{"sha":"f3edb21f027b70974750649ba29b0090e410ecde","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-27T17:33:49Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-27T17:33:49Z"},"message":"Updating
+        translations for translations/el_GR/sample.po","tree":{"sha":"fb0bb964adae138921edd29647d100350a0a25d0","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/fb0bb964adae138921edd29647d100350a0a25d0"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f3edb21f027b70974750649ba29b0090e410ecde","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f3edb21f027b70974750649ba29b0090e410ecde","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f3edb21f027b70974750649ba29b0090e410ecde","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f3edb21f027b70974750649ba29b0090e410ecde/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"89275cd4a7b4f36f00282689610cec9b2a970834","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/89275cd4a7b4f36f00282689610cec9b2a970834","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/89275cd4a7b4f36f00282689610cec9b2a970834"}],"stats":{"total":2,"additions":1,"deletions":1},"files":[{"sha":"540a3d944ac19f573e756de687c8c4f3f9847b53","filename":"translations/el_GR/sample.po","status":"modified","additions":1,"deletions":1,"changes":2,"blob_url":"https://github.com/txgh-bot/txgh-test-resources/blob/f3edb21f027b70974750649ba29b0090e410ecde/translations/el_GR/sample.po","raw_url":"https://github.com/txgh-bot/txgh-test-resources/raw/f3edb21f027b70974750649ba29b0090e410ecde/translations/el_GR/sample.po","contents_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/contents/translations/el_GR/sample.po?ref=f3edb21f027b70974750649ba29b0090e410ecde","patch":"@@
+        -9,7 +9,7 @@ msgstr \"\"\n \"Project-Id-Version: test-project\\n\"\n \"Report-Msgid-Bugs-To:
+        \\n\"\n \"POT-Creation-Date: 2015-02-17 20:10+0000\\n\"\n-\"PO-Revision-Date:
+        2016-02-05 23:57+0000\\n\"\n+\"PO-Revision-Date: 2016-01-19 19:08+0000\\n\"\n
+        \"Last-Translator: Ilias-Dimitrios Vrachnis\\n\"\n \"Language-Team: Greek
+        (Greece) (http://www.transifex.com/txgh-test/test-project-88/language/el_GR/)\\n\"\n
+        \"MIME-Version: 1.0\\n\""}]}'
+    http_version: 
+  recorded_at: Fri, 29 Apr 2016 16:06:57 GMT
 - request:
     method: post
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs
@@ -86,7 +249,7 @@ http_interactions:
       Accept:
       - application/vnd.github.v3+json
       User-Agent:
-      - Octokit Ruby Gem 4.2.0
+      - Octokit Ruby Gem 4.3.0
       Content-Type:
       - application/json
       Authorization:
@@ -101,7 +264,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Fri, 12 Feb 2016 19:48:52 GMT
+      - Fri, 29 Apr 2016 16:07:00 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -111,11 +274,14 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4999'
+      - '4986'
       X-Ratelimit-Reset:
-      - '1455310132'
+      - '1461949570'
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
       Etag:
       - '"ed992de3605511d4d93bfd55ab933696"'
       X-Oauth-Scopes:
@@ -124,13 +290,8 @@ http_interactions:
       - ''
       Location:
       - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/540a3d944ac19f573e756de687c8c4f3f9847b53
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding
       X-Github-Media-Type:
       - github.v3; format=json
-      Access-Control-Allow-Credentials:
-      - 'true'
       Access-Control-Expose-Headers:
       - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
         X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
@@ -147,14 +308,249 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - 593010132f82159af0ded24b4932e109
+      - 7b641bda7ec2ca7cd9df72d2578baf75
       X-Github-Request-Id:
-      - 04358C36:14596:F6290D5:56BE3724
+      - 438EEBFC:76D7:19A400E9:572386A1
     body:
       encoding: UTF-8
       string: '{"sha":"540a3d944ac19f573e756de687c8c4f3f9847b53","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/540a3d944ac19f573e756de687c8c4f3f9847b53"}'
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:48:52 GMT
+  recorded_at: Fri, 29 Apr 2016 16:07:01 GMT
+- request:
+    method: post
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees
+    body:
+      encoding: UTF-8
+      string: '{"base_tree":"fb0bb964adae138921edd29647d100350a0a25d0","tree":[{"path":"translations/el_GR/sample.po","mode":"100644","type":"blob","sha":"540a3d944ac19f573e756de687c8c4f3f9847b53"}]}'
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 29 Apr 2016 16:07:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1323'
+      Status:
+      - 201 Created
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4985'
+      X-Ratelimit-Reset:
+      - '1461949570'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - '"ee25b6150834713923850d7c815c3c39"'
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Location:
+      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/fb0bb964adae138921edd29647d100350a0a25d0
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - 07ff1c8a09e44b62e277fae50a1b1dc4
+      X-Github-Request-Id:
+      - 438EEBFC:76D5:248FA4A1:572386A5
+    body:
+      encoding: UTF-8
+      string: '{"sha":"fb0bb964adae138921edd29647d100350a0a25d0","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/fb0bb964adae138921edd29647d100350a0a25d0","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"cee445fa5bceaeb83c8d443b28f1647c2feff565","size":53,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/cee445fa5bceaeb83c8d443b28f1647c2feff565"},{"path":"sample.po","mode":"100644","type":"blob","sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6"},{"path":"test.yml","mode":"100644","type":"blob","sha":"7f2c77eec6692bc2ef95f7a7baede6e84179fe1d","size":44,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/7f2c77eec6692bc2ef95f7a7baede6e84179fe1d"},{"path":"translations","mode":"040000","type":"tree","sha":"64881902c6515e26c22e022abc0bedeaa15eafdc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/64881902c6515e26c22e022abc0bedeaa15eafdc"},{"path":"tx.config","mode":"100644","type":"blob","sha":"294be94dbb8d1d2ae6d30c51869912ff3a0d9e40","size":295,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/294be94dbb8d1d2ae6d30c51869912ff3a0d9e40"}],"truncated":false}'
+    http_version: 
+  recorded_at: Fri, 29 Apr 2016 16:07:06 GMT
+- request:
+    method: post
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits
+    body:
+      encoding: UTF-8
+      string: '{"message":"Updating translations for translations/el_GR/sample.po","tree":"fb0bb964adae138921edd29647d100350a0a25d0","parents":["f3edb21f027b70974750649ba29b0090e410ecde"]}'
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 29 Apr 2016 16:07:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '990'
+      Status:
+      - 201 Created
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4984'
+      X-Ratelimit-Reset:
+      - '1461949570'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - '"2b5680dc5bfdac9282ee911424290f33"'
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Location:
+      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/239f32750810ac8f366f0e81dc9f59e12e467dbd
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - a474937f3b2fa272558fa6dc951018ad
+      X-Github-Request-Id:
+      - 438EEBFC:76D0:74E0358:572386AB
+    body:
+      encoding: UTF-8
+      string: '{"sha":"239f32750810ac8f366f0e81dc9f59e12e467dbd","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/239f32750810ac8f366f0e81dc9f59e12e467dbd","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/239f32750810ac8f366f0e81dc9f59e12e467dbd","author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-29T16:07:09Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-29T16:07:09Z"},"tree":{"sha":"fb0bb964adae138921edd29647d100350a0a25d0","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/fb0bb964adae138921edd29647d100350a0a25d0"},"message":"Updating
+        translations for translations/el_GR/sample.po","parents":[{"sha":"f3edb21f027b70974750649ba29b0090e410ecde","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f3edb21f027b70974750649ba29b0090e410ecde","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f3edb21f027b70974750649ba29b0090e410ecde"}]}'
+    http_version: 
+  recorded_at: Fri, 29 Apr 2016 16:07:10 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/compare/f3edb21f027b70974750649ba29b0090e410ecde...239f32750810ac8f366f0e81dc9f59e12e467dbd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token <GITHUB_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 29 Apr 2016 16:07:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4983'
+      X-Ratelimit-Reset:
+      - '1461949570'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"f26d4497b0d6852e8df96aacb42ed451"
+      Last-Modified:
+      - Fri, 29 Apr 2016 16:07:09 GMT
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Served-By:
+      - 07ff1c8a09e44b62e277fae50a1b1dc4
+      X-Github-Request-Id:
+      - 438EEBFC:76D6:29C55EF8:572386AE
+    body:
+      encoding: UTF-8
+      string: '{"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/compare/f3edb21f027b70974750649ba29b0090e410ecde...239f32750810ac8f366f0e81dc9f59e12e467dbd","html_url":"https://github.com/txgh-bot/txgh-test-resources/compare/f3edb21f027b70974750649ba29b0090e410ecde...239f32750810ac8f366f0e81dc9f59e12e467dbd","permalink_url":"https://github.com/txgh-bot/txgh-test-resources/compare/txgh-bot:f3edb21...txgh-bot:239f327","diff_url":"https://github.com/txgh-bot/txgh-test-resources/compare/f3edb21f027b70974750649ba29b0090e410ecde...239f32750810ac8f366f0e81dc9f59e12e467dbd.diff","patch_url":"https://github.com/txgh-bot/txgh-test-resources/compare/f3edb21f027b70974750649ba29b0090e410ecde...239f32750810ac8f366f0e81dc9f59e12e467dbd.patch","base_commit":{"sha":"f3edb21f027b70974750649ba29b0090e410ecde","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-27T17:33:49Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-27T17:33:49Z"},"message":"Updating
+        translations for translations/el_GR/sample.po","tree":{"sha":"fb0bb964adae138921edd29647d100350a0a25d0","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/fb0bb964adae138921edd29647d100350a0a25d0"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f3edb21f027b70974750649ba29b0090e410ecde","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f3edb21f027b70974750649ba29b0090e410ecde","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f3edb21f027b70974750649ba29b0090e410ecde","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f3edb21f027b70974750649ba29b0090e410ecde/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"89275cd4a7b4f36f00282689610cec9b2a970834","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/89275cd4a7b4f36f00282689610cec9b2a970834","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/89275cd4a7b4f36f00282689610cec9b2a970834"}]},"merge_base_commit":{"sha":"f3edb21f027b70974750649ba29b0090e410ecde","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-27T17:33:49Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-27T17:33:49Z"},"message":"Updating
+        translations for translations/el_GR/sample.po","tree":{"sha":"fb0bb964adae138921edd29647d100350a0a25d0","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/fb0bb964adae138921edd29647d100350a0a25d0"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f3edb21f027b70974750649ba29b0090e410ecde","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f3edb21f027b70974750649ba29b0090e410ecde","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f3edb21f027b70974750649ba29b0090e410ecde","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f3edb21f027b70974750649ba29b0090e410ecde/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"89275cd4a7b4f36f00282689610cec9b2a970834","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/89275cd4a7b4f36f00282689610cec9b2a970834","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/89275cd4a7b4f36f00282689610cec9b2a970834"}]},"status":"ahead","ahead_by":1,"behind_by":0,"total_commits":1,"commits":[{"sha":"239f32750810ac8f366f0e81dc9f59e12e467dbd","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-29T16:07:09Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-04-29T16:07:09Z"},"message":"Updating
+        translations for translations/el_GR/sample.po","tree":{"sha":"fb0bb964adae138921edd29647d100350a0a25d0","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/fb0bb964adae138921edd29647d100350a0a25d0"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/239f32750810ac8f366f0e81dc9f59e12e467dbd","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/239f32750810ac8f366f0e81dc9f59e12e467dbd","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/239f32750810ac8f366f0e81dc9f59e12e467dbd","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/239f32750810ac8f366f0e81dc9f59e12e467dbd/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"f3edb21f027b70974750649ba29b0090e410ecde","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f3edb21f027b70974750649ba29b0090e410ecde","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f3edb21f027b70974750649ba29b0090e410ecde"}]}],"files":[]}'
+    http_version: 
+  recorded_at: Fri, 29 Apr 2016 16:07:14 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master
@@ -165,7 +561,7 @@ http_interactions:
       Accept:
       - application/vnd.github.v3+json
       User-Agent:
-      - Octokit Ruby Gem 4.2.0
+      - Octokit Ruby Gem 4.3.0
       Content-Type:
       - application/json
       Authorization:
@@ -180,7 +576,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Fri, 12 Feb 2016 19:48:52 GMT
+      - Fri, 29 Apr 2016 16:07:17 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -190,28 +586,26 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4998'
+      - '4982'
       X-Ratelimit-Reset:
-      - '1455310132'
+      - '1461949570'
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"a5fe675407899fa4460005cce07b9fe2"
       Last-Modified:
       - Mon, 11 Jan 2016 23:45:43 GMT
-      Etag:
-      - W/"2c789545a86986f3dbe3ca967407cb88"
       X-Poll-Interval:
       - '300'
       X-Oauth-Scopes:
       - public_repo
       X-Accepted-Oauth-Scopes:
       - ''
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding
       X-Github-Media-Type:
       - github.v3; format=json
-      Access-Control-Allow-Credentials:
-      - 'true'
       Access-Control-Expose-Headers:
       - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
         X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
@@ -228,333 +622,12 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Served-By:
-      - a30e6f9aa7cf5731b87dfb3b9992202d
+      - 8a5c38021a5cd7cef7b8f49a296fee40
       X-Github-Request-Id:
-      - 04358C36:14596:F62915C:56BE3724
+      - 438EEBFC:DA3E:27043083:572386B3
     body:
       encoding: UTF-8
-      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"e411b627bdb8884f66748d48fcd9576f61992085","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/e411b627bdb8884f66748d48fcd9576f61992085"}}'
+      string: '{"ref":"refs/heads/master","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/refs/heads/master","object":{"sha":"f3edb21f027b70974750649ba29b0090e410ecde","type":"commit","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/f3edb21f027b70974750649ba29b0090e410ecde"}}'
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:48:52 GMT
-- request:
-    method: get
-    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/e411b627bdb8884f66748d48fcd9576f61992085
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Octokit Ruby Gem 4.2.0
-      Content-Type:
-      - application/json
-      Authorization:
-      - token <GITHUB_TOKEN>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Fri, 12 Feb 2016 19:48:53 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4997'
-      X-Ratelimit-Reset:
-      - '1455310132'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Last-Modified:
-      - Mon, 01 Feb 2016 20:15:13 GMT
-      Etag:
-      - W/"5c055175960a69cba21e17c0a0507135"
-      X-Oauth-Scopes:
-      - public_repo
-      X-Accepted-Oauth-Scopes:
-      - ''
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Served-By:
-      - bd82876e9bf04990f289ba22f246ee9b
-      X-Github-Request-Id:
-      - 04358C36:14594:ED057EF:56BE3724
-    body:
-      encoding: UTF-8
-      string: '{"sha":"e411b627bdb8884f66748d48fcd9576f61992085","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-01T20:15:13Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-01T20:15:13Z"},"message":"Updating
-        translations for translations/el_GR/sample.po","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/e411b627bdb8884f66748d48fcd9576f61992085","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/e411b627bdb8884f66748d48fcd9576f61992085","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/e411b627bdb8884f66748d48fcd9576f61992085","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/e411b627bdb8884f66748d48fcd9576f61992085/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"f0356f2c6216af45b74a517835a6b8d11c246a33","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f0356f2c6216af45b74a517835a6b8d11c246a33","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f0356f2c6216af45b74a517835a6b8d11c246a33"}],"stats":{"total":0,"additions":0,"deletions":0},"files":[]}'
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:48:53 GMT
-- request:
-    method: post
-    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees
-    body:
-      encoding: UTF-8
-      string: '{"base_tree":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","tree":[{"path":"translations/el_GR/sample.po","mode":"100644","type":"blob","sha":"540a3d944ac19f573e756de687c8c4f3f9847b53"}]}'
-    headers:
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Octokit Ruby Gem 4.2.0
-      Content-Type:
-      - application/json
-      Authorization:
-      - token <GITHUB_TOKEN>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Fri, 12 Feb 2016 19:48:53 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '869'
-      Status:
-      - 201 Created
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4996'
-      X-Ratelimit-Reset:
-      - '1455310132'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Etag:
-      - '"285d1085d15dc469819c68a1aafc59be"'
-      X-Oauth-Scopes:
-      - public_repo
-      X-Accepted-Oauth-Scopes:
-      - ''
-      Location:
-      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Served-By:
-      - bae57931a6fe678a3dffe9be8e7819c8
-      X-Github-Request-Id:
-      - 04358C36:14594:ED05873:56BE3725
-    body:
-      encoding: UTF-8
-      string: '{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"cee445fa5bceaeb83c8d443b28f1647c2feff565","size":53,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/cee445fa5bceaeb83c8d443b28f1647c2feff565"},{"path":"sample.po","mode":"100644","type":"blob","sha":"a93e31a00137e0bd23db5bc7720568f8e908b2b6","size":855,"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/blobs/a93e31a00137e0bd23db5bc7720568f8e908b2b6"},{"path":"translations","mode":"040000","type":"tree","sha":"64881902c6515e26c22e022abc0bedeaa15eafdc","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/64881902c6515e26c22e022abc0bedeaa15eafdc"}],"truncated":false}'
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:48:53 GMT
-- request:
-    method: post
-    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits
-    body:
-      encoding: UTF-8
-      string: '{"message":"Updating translations for translations/el_GR/sample.po","tree":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","parents":["e411b627bdb8884f66748d48fcd9576f61992085"]}'
-    headers:
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Octokit Ruby Gem 4.2.0
-      Content-Type:
-      - application/json
-      Authorization:
-      - token <GITHUB_TOKEN>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Fri, 12 Feb 2016 19:48:53 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '990'
-      Status:
-      - 201 Created
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4995'
-      X-Ratelimit-Reset:
-      - '1455310132'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Etag:
-      - '"eab520784a635017e6368014dfe7743c"'
-      X-Oauth-Scopes:
-      - public_repo
-      X-Accepted-Oauth-Scopes:
-      - ''
-      Location:
-      - https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/8a9e9df3d02fa7cacd39017b534a24f564ccdf72
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Served-By:
-      - e183f7c661b1bbc2c987b3c4dc7b04e0
-      X-Github-Request-Id:
-      - 04358C36:14594:ED05902:56BE3725
-    body:
-      encoding: UTF-8
-      string: '{"sha":"8a9e9df3d02fa7cacd39017b534a24f564ccdf72","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/8a9e9df3d02fa7cacd39017b534a24f564ccdf72","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/8a9e9df3d02fa7cacd39017b534a24f564ccdf72","author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-12T19:48:53Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-12T19:48:53Z"},"tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"message":"Updating
-        translations for translations/el_GR/sample.po","parents":[{"sha":"e411b627bdb8884f66748d48fcd9576f61992085","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/e411b627bdb8884f66748d48fcd9576f61992085","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/e411b627bdb8884f66748d48fcd9576f61992085"}]}'
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:48:53 GMT
-- request:
-    method: get
-    uri: https://api.github.com/repos/txgh-bot/txgh-test-resources/compare/e411b627bdb8884f66748d48fcd9576f61992085...8a9e9df3d02fa7cacd39017b534a24f564ccdf72
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Octokit Ruby Gem 4.2.0
-      Content-Type:
-      - application/json
-      Authorization:
-      - token <GITHUB_TOKEN>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Fri, 12 Feb 2016 19:48:54 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4994'
-      X-Ratelimit-Reset:
-      - '1455310132'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Last-Modified:
-      - Fri, 12 Feb 2016 19:48:53 GMT
-      Etag:
-      - W/"8c0f4cf6a2ab558c59ba29b3abab9522"
-      X-Oauth-Scopes:
-      - public_repo
-      X-Accepted-Oauth-Scopes:
-      - ''
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Served-By:
-      - 2c18a09f3ac5e4dd1e004af7c5a94769
-      X-Github-Request-Id:
-      - 04358C36:14594:ED0599F:56BE3726
-    body:
-      encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/compare/e411b627bdb8884f66748d48fcd9576f61992085...8a9e9df3d02fa7cacd39017b534a24f564ccdf72","html_url":"https://github.com/txgh-bot/txgh-test-resources/compare/e411b627bdb8884f66748d48fcd9576f61992085...8a9e9df3d02fa7cacd39017b534a24f564ccdf72","permalink_url":"https://github.com/txgh-bot/txgh-test-resources/compare/txgh-bot:e411b62...txgh-bot:8a9e9df","diff_url":"https://github.com/txgh-bot/txgh-test-resources/compare/e411b627bdb8884f66748d48fcd9576f61992085...8a9e9df3d02fa7cacd39017b534a24f564ccdf72.diff","patch_url":"https://github.com/txgh-bot/txgh-test-resources/compare/e411b627bdb8884f66748d48fcd9576f61992085...8a9e9df3d02fa7cacd39017b534a24f564ccdf72.patch","base_commit":{"sha":"e411b627bdb8884f66748d48fcd9576f61992085","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-01T20:15:13Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-01T20:15:13Z"},"message":"Updating
-        translations for translations/el_GR/sample.po","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/e411b627bdb8884f66748d48fcd9576f61992085","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/e411b627bdb8884f66748d48fcd9576f61992085","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/e411b627bdb8884f66748d48fcd9576f61992085","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/e411b627bdb8884f66748d48fcd9576f61992085/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"f0356f2c6216af45b74a517835a6b8d11c246a33","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f0356f2c6216af45b74a517835a6b8d11c246a33","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f0356f2c6216af45b74a517835a6b8d11c246a33"}]},"merge_base_commit":{"sha":"e411b627bdb8884f66748d48fcd9576f61992085","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-01T20:15:13Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-01T20:15:13Z"},"message":"Updating
-        translations for translations/el_GR/sample.po","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/e411b627bdb8884f66748d48fcd9576f61992085","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/e411b627bdb8884f66748d48fcd9576f61992085","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/e411b627bdb8884f66748d48fcd9576f61992085","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/e411b627bdb8884f66748d48fcd9576f61992085/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"f0356f2c6216af45b74a517835a6b8d11c246a33","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/f0356f2c6216af45b74a517835a6b8d11c246a33","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/f0356f2c6216af45b74a517835a6b8d11c246a33"}]},"status":"ahead","ahead_by":1,"behind_by":0,"total_commits":1,"commits":[{"sha":"8a9e9df3d02fa7cacd39017b534a24f564ccdf72","commit":{"author":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-12T19:48:53Z"},"committer":{"name":"txgh-bot","email":"txgh.bot@gmail.com","date":"2016-02-12T19:48:53Z"},"message":"Updating
-        translations for translations/el_GR/sample.po","tree":{"sha":"4ee65f809366225a4d575ad47f0f8c2a05a6d460","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/trees/4ee65f809366225a4d575ad47f0f8c2a05a6d460"},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/git/commits/8a9e9df3d02fa7cacd39017b534a24f564ccdf72","comment_count":0},"url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/8a9e9df3d02fa7cacd39017b534a24f564ccdf72","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/8a9e9df3d02fa7cacd39017b534a24f564ccdf72","comments_url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/8a9e9df3d02fa7cacd39017b534a24f564ccdf72/comments","author":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"committer":{"login":"txgh-bot","id":16723366,"avatar_url":"https://avatars.githubusercontent.com/u/16723366?v=3","gravatar_id":"","url":"https://api.github.com/users/txgh-bot","html_url":"https://github.com/txgh-bot","followers_url":"https://api.github.com/users/txgh-bot/followers","following_url":"https://api.github.com/users/txgh-bot/following{/other_user}","gists_url":"https://api.github.com/users/txgh-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/txgh-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/txgh-bot/subscriptions","organizations_url":"https://api.github.com/users/txgh-bot/orgs","repos_url":"https://api.github.com/users/txgh-bot/repos","events_url":"https://api.github.com/users/txgh-bot/events{/privacy}","received_events_url":"https://api.github.com/users/txgh-bot/received_events","type":"User","site_admin":false},"parents":[{"sha":"e411b627bdb8884f66748d48fcd9576f61992085","url":"https://api.github.com/repos/txgh-bot/txgh-test-resources/commits/e411b627bdb8884f66748d48fcd9576f61992085","html_url":"https://github.com/txgh-bot/txgh-test-resources/commit/e411b627bdb8884f66748d48fcd9576f61992085"}]}],"files":[]}'
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:48:54 GMT
+  recorded_at: Fri, 29 Apr 2016 16:07:18 GMT
 recorded_with: VCR 3.0.1

--- a/spec/resource_committer_spec.rb
+++ b/spec/resource_committer_spec.rb
@@ -14,18 +14,44 @@ describe ResourceCommitter do
     ResourceCommitter.new(transifex_project, github_repo, logger)
   end
 
+  before(:each) do
+    allow(github_api).to receive(:get_ref).and_return(
+      object: { sha: 'abc123shashasha' }
+    )
+  end
+
   describe '#commit_resource' do
-    it 'commits translations to the git repo' do
-      expect(ResourceDownloader).to receive(:new).and_return(downloader)
-      expect(downloader).to receive(:first).and_return([file_name, :translations])
+    context 'with apis available' do
+      before(:each) do
+        expect(ResourceDownloader).to receive(:new).and_return(downloader)
+        expect(downloader).to receive(:first).and_return([file_name, :translations])
 
-      expect(github_api).to(
-        receive(:commit).with(
-          repo_name, branch, { file_name => :translations }
+        expect(github_api).to(
+          receive(:commit).with(
+            repo_name, branch, { file_name => :translations }
+          )
         )
-      )
+      end
 
-      committer.commit_resource(resource, branch, language)
+      it 'commits translations to the git repo' do
+        committer.commit_resource(resource, branch, language)
+      end
+
+      it 'fires the github.resource.committed event' do
+        expect { committer.commit_resource(resource, branch, language) }.to(
+          change { Txgh.events.published.size }.by(1)
+        )
+
+        event = Txgh.events.published.first
+        expect(event[:channel]).to eq('github.resource.committed')
+
+        options = event[:options]
+        expect(options[:project].name).to eq(project_name)
+        expect(options[:repo].name).to eq(repo_name)
+        expect(options[:sha]).to eq('abc123shashasha')
+        expect(options[:resource].original_resource_slug).to eq(resource_slug)
+        expect(options[:language]).to eq(language)
+      end
     end
 
     it "doesn't commit anything if the language is the source language" do

--- a/spec/resource_updater_spec.rb
+++ b/spec/resource_updater_spec.rb
@@ -65,6 +65,23 @@ describe ResourceUpdater do
     updater.update_resource(resource, commit_sha)
   end
 
+  it 'fires the transifex.resource.updated event' do
+    allow(transifex_api).to receive(:create_or_update)
+
+    expect { updater.update_resource(resource, commit_sha) }.to(
+      change { Txgh.events.published.size }.by(1)
+    )
+
+    event = Txgh.events.published.first
+    expect(event[:channel]).to eq('transifex.resource.updated')
+
+    options = event[:options]
+    expect(options[:project].name).to eq(project_name)
+    expect(options[:repo].name).to eq(repo_name)
+    expect(options[:sha]).to eq(commit_sha)
+    expect(options[:resource].original_resource_slug).to eq(resource_slug)
+  end
+
   context 'when asked to process all branches' do
     let(:branch) { 'all' }
     let(:ref) { 'heads/master' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ require 'vcr'
 require 'webmock'
 require 'yaml'
 
+require 'helpers/test_events'
+
 module SpecHelpers
   def outdent(str)
     # The special YAML pipe operator treats the text that follows as literal,
@@ -24,6 +26,10 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run_excluding(integration: true) unless ENV['FULL_SPEC']
   config.include(SpecHelpers)
+
+  config.before(:each) do
+    Txgh.instance_variable_set(:@events, TestEvents.new)
+  end
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
A la Solano or Travis. Uses github's [status api](https://developer.github.com/v3/repos/statuses/).

@lumoslabs/platform 

<img width="783" alt="statuses" src="https://cloud.githubusercontent.com/assets/575280/14922163/db422406-0dea-11e6-9dab-16a68fdc7d1f.png">
