### PR TITLE
Include the branch in the resource's name

### DIFF
--- a/lib/txgh/transifex_api.rb
+++ b/lib/txgh/transifex_api.rb
@@ -50,9 +50,15 @@ module Txgh
     end
 
     def create(tx_resource, content, categories = [])
+      name = if tx_resource.branch
+        "#{tx_resource.source_file} (#{tx_resource.branch})"
+      else
+        tx_resource.source_file
+      end
+
       payload = {
         slug: tx_resource.resource_slug,
-        name: tx_resource.source_file,
+        name: name,
         i18n_type: tx_resource.type,
         categories: CategorySupport.join_categories(categories.uniq),
         content: get_content_io(tx_resource, content)


### PR DESCRIPTION
Currently each resource's name is just the source file path. Since we have one or more resources per branch, a bunch of our resources have identical names. This isn't technically a problem, but it does make it difficult to disambiguate between resources when digging through the Transifex UI.

@lumoslabs/platform 
