### PR TITLE
Adding environment to txgh

### DIFF
--- a/lib/txgh.rb
+++ b/lib/txgh.rb
@@ -30,6 +30,8 @@ module Txgh
   autoload :TxResource,            'txgh/tx_resource'
   autoload :Utils,                 'txgh/utils'
 
+  DEFAULT_ENV = 'development'
+
   class << self
     def tx_manager
       Txgh::Config::TxManager
@@ -53,6 +55,10 @@ module Txgh
       resource = options.fetch(:resource)
 
       GithubStatus.new(project, repo, resource).update(options.fetch(:sha))
+    end
+
+    def env
+      ENV.fetch('TXGH_ENV', DEFAULT_ENV)
     end
   end
 

--- a/spec/txgh_spec.rb
+++ b/spec/txgh_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Txgh do
+  def with_env(env)
+    # ENV can't be duped, so use select instead to make a copy
+    old_env = ENV.select { true }
+    env.each_pair { |k, v| ENV[k] = v }
+    yield
+  ensure
+    # reset back to old vars
+    env.each_pair { |k, _| ENV[k] = old_env[k] }
+  end
+
+  describe '#env' do
+    it 'defaults to development' do
+      expect(Txgh.env).to eq('development')
+    end
+
+    it 'pulls the env out of ENV if set' do
+      with_env('TXGH_ENV' => 'production') do
+        expect(Txgh.env).to eq('production')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Exposes a top-level method accessible via `Txgh.env` that reads from the `TXGH_ENV` environment variable. Not used internally at the moment.

@lumoslabs/platform 
