### PR TITLE
Default tx config scheme

### DIFF
--- a/lib/txgh.rb
+++ b/lib/txgh.rb
@@ -65,7 +65,7 @@ module Txgh
   # default set of tx config providers
   tx_manager.register_provider(providers::FileProvider, Txgh::Config::TxConfig)
   tx_manager.register_provider(providers::GitProvider,  Txgh::Config::TxConfig)
-  tx_manager.register_provider(providers::RawProvider,  Txgh::Config::TxConfig)
+  tx_manager.register_provider(providers::RawProvider,  Txgh::Config::TxConfig, default: true)
 
   # default set of base config providers
   key_manager.register_provider(providers::FileProvider, YAML)

--- a/lib/txgh/config/provider_instance.rb
+++ b/lib/txgh/config/provider_instance.rb
@@ -1,11 +1,12 @@
 module Txgh
   module Config
     class ProviderInstance
-      attr_reader :provider, :parser
+      attr_reader :provider, :parser, :options
 
-      def initialize(provider, parser)
+      def initialize(provider, parser, options = {})
         @provider = provider
         @parser = parser
+        @options = options
       end
 
       def supports?(*args)
@@ -14,6 +15,10 @@ module Txgh
 
       def load(payload, options = {})
         provider.load(payload, parser, options)
+      end
+
+      def default?
+        !!(options[:default])
       end
     end
   end

--- a/lib/txgh/config/provider_support.rb
+++ b/lib/txgh/config/provider_support.rb
@@ -1,8 +1,8 @@
 module Txgh
   module Config
     module ProviderSupport
-      def register_provider(provider, parser)
-        providers << ProviderInstance.new(provider, parser)
+      def register_provider(provider, parser, options = {})
+        providers << ProviderInstance.new(provider, parser, options)
       end
 
       def providers
@@ -10,7 +10,8 @@ module Txgh
       end
 
       def provider_for(scheme)
-        providers.find { |provider| provider.supports?(scheme) }
+        provider = providers.find { |provider| provider.supports?(scheme) }
+        provider || providers.find(&:default?)
       end
 
       def split_uri(uri)

--- a/lib/txgh/config/providers/file_provider.rb
+++ b/lib/txgh/config/providers/file_provider.rb
@@ -12,6 +12,10 @@ module Txgh
           def load(payload, parser, options = {})
             parser.load_file(payload)
           end
+
+          def scheme
+            SCHEME
+          end
         end
       end
     end

--- a/lib/txgh/config/providers/git_provider.rb
+++ b/lib/txgh/config/providers/git_provider.rb
@@ -12,6 +12,10 @@ module Txgh
           def load(payload, parser, options = {})
             new(payload, parser, options).config
           end
+
+          def scheme
+            SCHEME
+          end
         end
 
         attr_reader :payload, :parser

--- a/lib/txgh/config/providers/raw_provider.rb
+++ b/lib/txgh/config/providers/raw_provider.rb
@@ -12,6 +12,10 @@ module Txgh
           def load(payload, parser, options = {})
             parser.load(payload)
           end
+
+          def scheme
+            SCHEME
+          end
         end
       end
     end

--- a/spec/config/provider_instance_spec.rb
+++ b/spec/config/provider_instance_spec.rb
@@ -21,6 +21,20 @@ describe ProviderInstance do
     end
   end
 
+  describe '#default' do
+    it 'returns false if not the default provider' do
+      expect(instance).to_not be_default
+    end
+
+    context 'with a default provider' do
+      let(:instance) { ProviderInstance.new(provider, parser, default: true) }
+
+      it 'returns true if marked as the default provider' do
+        expect(instance).to be_default
+      end
+    end
+  end
+
   describe '#load' do
     it "calls the provider's load method passing the parser and options" do
       expect(provider).to receive(:load).with(payload, parser, options)

--- a/spec/config/provider_support_spec.rb
+++ b/spec/config/provider_support_spec.rb
@@ -50,6 +50,24 @@ describe ProviderSupport do
         expect(instance.provider).to eq(provider)
         expect(instance.parser).to eq(:fake_parser)
       end
+
+      it 'returns nil when passed an unrecognizable scheme' do
+        expect(klass.provider_for('foo')).to be_nil
+      end
+    end
+  end
+
+  context 'with a default registered provider' do
+    before(:each) do
+      klass.register_provider(provider, :fake_parser, default: true)
+    end
+
+    describe '#provider_for' do
+      it 'returns the default provider when passed an unrecognizable scheme' do
+        instance = klass.provider_for('foo')
+        expect(instance.provider).to eq(provider)
+        expect(instance.parser).to eq(:fake_parser)
+      end
     end
   end
 end

--- a/spec/txgh_spec.rb
+++ b/spec/txgh_spec.rb
@@ -22,4 +22,11 @@ describe Txgh do
       end
     end
   end
+
+  describe 'providers' do
+    it 'defaults to the raw tx config provider' do
+      instance = Txgh.tx_manager.provider_for('foo')
+      expect(instance.provider.scheme).to eq('raw')
+    end
+  end
 end


### PR DESCRIPTION
[PLAT-1074](https://lumoslabs.atlassian.net/browse/PLAT-1074). Makes the `raw://` tx config scheme the default.

@lumoslabs/platform
