### PR TITLE
Fix escaping for Transifex JSON api responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ./Gemfile /usr/src/app/
 COPY ./Gemfile.lock /usr/src/app/
 COPY ./txgh.gemspec /usr/src/app/
 COPY ./lib/txgh/version.rb /usr/src/app/lib/txgh/
-RUN bundle install --jobs=3 --retry=3
+RUN bundle install --jobs=3 --retry=3 --without development test
 
 COPY . /usr/src/app
 

--- a/bootstrap.rb
+++ b/bootstrap.rb
@@ -1,2 +1,0 @@
-$:.unshift File::dirname(__FILE__)
-$:.unshift "#{File::dirname(__FILE__)}/lib"

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,6 @@
-require_relative 'bootstrap'
+$:.unshift(File.dirname(__FILE__))
+$:.unshift(File.join(File.dirname(__FILE__), 'lib'))
+
 require 'txgh'
 
 map '/' do

--- a/lib/txgh/transifex_api.rb
+++ b/lib/txgh/transifex_api.rb
@@ -105,7 +105,9 @@ module Txgh
       raise_error!(response)
 
       json_data = JSON.parse(response.body)
-      json_data['content']
+      content = json_data['content']
+
+      tx_resource.json? ? escape_json(content) : content
     end
 
     def get_resource(project_slug, resource_slug)
@@ -151,6 +153,10 @@ module Txgh
     end
 
     private
+
+    def escape_json(text)
+      text.gsub("\r", %q(\r)).gsub("\n", %q(\n))
+    end
 
     def get_content_io(tx_resource, content)
       content_io = StringIO::new(content)

--- a/lib/txgh/tx_branch_resource.rb
+++ b/lib/txgh/tx_branch_resource.rb
@@ -7,7 +7,7 @@ module Txgh
     def_delegators :@resource, *[
       :project_slug, :type, :source_lang, :source_file, :L10N_resource_slug,
       :translation_file, :lang_map, :translation_path, :original_resource_slug,
-      :to_h, :to_api_h
+      :to_h, :to_api_h, :json?
     ]
 
     attr_reader :resource, :branch

--- a/lib/txgh/tx_resource.rb
+++ b/lib/txgh/tx_resource.rb
@@ -1,5 +1,6 @@
 module Txgh
   class TxResource
+    JSON_TYPES = %w(CHROME KEYVALUEJSON RESJSON)
     attr_reader :project_slug, :resource_slug, :type, :source_lang
     attr_reader :source_file, :translation_file
 
@@ -25,6 +26,10 @@ module Txgh
       end
 
       @translation_file = translation_file
+    end
+
+    def json?
+      JSON_TYPES.include?(type)
     end
 
     def L10N_resource_slug

--- a/spec/helpers/standard_txgh_setup.rb
+++ b/spec/helpers/standard_txgh_setup.rb
@@ -20,6 +20,7 @@ module StandardTxghSetup
   let(:diff_point) { nil }
   let(:organization) { 'myorg' }
   let(:commit_message_template) { nil }  # i.e. use the default
+  let(:type) { 'YML' }
 
   let(:project_config) do
     {
@@ -59,7 +60,7 @@ module StandardTxghSetup
     file_filter = translations/<lang>/sample.yml
     source_file = sample.yml
     source_lang = en
-    type = YML
+    type = #{type}
     """
   end
 

--- a/spec/transifex_api_spec.rb
+++ b/spec/transifex_api_spec.rb
@@ -244,6 +244,19 @@ describe TransifexApi do
         TransifexNotFoundError
       )
     end
+
+    context 'with a JSON resource' do
+      let(:type) { 'KEYVALUEJSON' }
+
+      it 'escapes newlines and carriage returns in JSON responses (potential Transifex bug)' do
+        allow(connection).to receive(:get).and_return(response)
+        allow(response).to receive(:status).and_return(200)
+        allow(response).to receive(:body).and_return(%q({"content": "[\"foo\nbar\"]"}))
+        content = api.download(resource, language)
+        expect { JSON.parse(content) }.to_not raise_error
+        expect(content).to eq(%q(["foo\nbar"]))
+      end
+    end
   end
 
   describe '#get_resource' do

--- a/spec/tx_resource_spec.rb
+++ b/spec/tx_resource_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 include Txgh
 
 describe TxResource do
+  let(:type) { 'type' }
+
   let(:resource) do
     TxResource.new(
-      'project_slug', 'resource_slug', 'type',
+      'project_slug', 'resource_slug', type,
       'source_lang', 'source_file', 'ko-KR:ko', 'translation_file'
     )
   end
@@ -29,6 +31,20 @@ describe TxResource do
   describe '#slugs' do
     it 'returns an array containing the project and resource slugs' do
       expect(resource.slugs).to eq(%w(project_slug resource_slug))
+    end
+  end
+
+  describe '#json?' do
+    it 'returns false if the resource is not in JSON format' do
+      expect(resource).to_not be_json
+    end
+
+    context 'with a json type' do
+      let(:type) { 'KEYVALUEJSON' }
+
+      it 'returns true if the resource is in JSON format' do
+        expect(resource).to be_json
+      end
     end
   end
 


### PR DESCRIPTION
Depending on how the translations are entered in Transifex's UI (raw mode or rich mode), the Transifex API may inadvertently return incorrectly escaped JSON.

@lumoslabs/platform
