### PR TITLE
Use tip of branch instead of commit sha when updating Transifex resources

### DIFF
--- a/spec/handlers/github/push_handler_spec.rb
+++ b/spec/handlers/github/push_handler_spec.rb
@@ -48,6 +48,12 @@ describe PushHandler do
           expect(categories).to eq('author' => 'Test User')
         end
       )
+
+      expect(github_api).to(
+        receive(:get_ref).with(repo_name, ref).and_return(
+          object: { sha: payload.head_commit[:id] }
+        )
+      )
     end
 
     response = handler.execute
@@ -65,6 +71,12 @@ describe PushHandler do
       expect(github_api).to(
         receive(:create_ref).with(
           repo_name, 'heads/L10N', payload.head_commit[:id]
+        )
+      )
+
+      expect(github_api).to(
+        receive(:get_ref).with(repo_name, ref).and_return(
+          object: { sha: payload.head_commit[:id] }
         )
       )
 


### PR DESCRIPTION
Currently we're using the SHAs from the webhook payload body to update Transifex resources. This means that webhook requests triggered by pushes to the same branch may actually get processed in the wrong order, i.e. more recent content may get overwritten by older content. This should work in all cases, even when txgh isn't configured to upload resources by branch. In the world of git, you're always pushing to _some_ branch, even if that branch is just master. In other words, commits are inherently chronological.

@lumoslabs/platform 
