### PR TITLE
Treat arrays as single units

### DIFF
--- a/txgh/History.txt
+++ b/txgh/History.txt
@@ -1,3 +1,6 @@
+== 5.4.1
+* Treat arrays as single units to conform to Transifex's string handling behavior.
+
 == 5.4.0
 * Separate txgh core library and server components.
 

--- a/txgh/lib/txgh/resource_contents.rb
+++ b/txgh/lib/txgh/resource_contents.rb
@@ -37,7 +37,7 @@ module Txgh
 
     def phrases
       @phrases ||= extractor.from_string(raw) do |extractor|
-        extractor.extract_each.map do |key, value|
+        extractor.extract_each(preserve_arrays: true).map do |key, value|
           { 'key' => key, 'string' => value }
         end
       end
@@ -56,7 +56,7 @@ module Txgh
       serializer.from_stream(stream, language) do |serializer|
         phrases.each do |phrase|
           serializer.write_key_value(
-            phrase['key'], (phrase['string'] || '').to_s
+            phrase['key'], str(phrase['string'] || '')
           )
         end
       end
@@ -94,6 +94,15 @@ module Txgh
     private
 
     attr_reader :raw
+
+    def str(obj)
+      case obj
+        when Array
+          obj
+        else
+          obj.to_s
+      end
+    end
 
     def extractor
       id = EXTRACTOR_MAP.fetch(tx_resource.type) do

--- a/txgh/lib/txgh/version.rb
+++ b/txgh/lib/txgh/version.rb
@@ -1,3 +1,3 @@
 module Txgh
-  VERSION = '5.4.0'
+  VERSION = '5.4.1'
 end

--- a/txgh/spec/diff_calculator_spec.rb
+++ b/txgh/spec/diff_calculator_spec.rb
@@ -35,6 +35,29 @@ describe DiffCalculator do
       end
     end
 
+    context 'with an array added to HEAD' do
+      let(:head_phrases) do
+        diff_point_phrases + [
+          phrase('villains', %w(Khan Chang Valeris Shinzon))
+        ]
+      end
+
+      let(:diff_point_phrases) do
+        [
+          phrase('Bajor', 'Bajoran'),
+          phrase('Cardassia', 'Cardassian')
+        ]
+      end
+
+      it 'includes the new array' do
+        expect(diff[:added].size).to eq(1)
+        expect(diff[:modified].size).to eq(0)
+        phrase = diff[:added].first
+        expect(phrase['key']).to eq('villains')
+        expect(phrase['string']).to eq(%w(Khan Chang Valeris Shinzon))
+      end
+    end
+
     context 'with phrases removed from HEAD' do
       let(:head_phrases) do
         []
@@ -45,6 +68,21 @@ describe DiffCalculator do
       end
 
       it 'does not include the new string if string has been removed' do
+        expect(diff[:added].size).to eq(0)
+        expect(diff[:modified].size).to eq(0)
+      end
+    end
+
+    context 'with an array removed from HEAD' do
+      let(:head_phrases) do
+        []
+      end
+
+      let(:diff_point_phrases) do
+        phrase('villains', %w(Khan Chang Valeris Shinzon))
+      end
+
+      it 'does not include the array' do
         expect(diff[:added].size).to eq(0)
         expect(diff[:modified].size).to eq(0)
       end
@@ -65,6 +103,24 @@ describe DiffCalculator do
         phrase = diff[:modified].first
         expect(phrase['key']).to eq('TheNextGeneration')
         expect(phrase['string']).to eq('Jean Luc Picard (rocks)')
+      end
+    end
+
+    context 'with an array modified in HEAD' do
+      let(:head_phrases) do
+        [phrase('villains', %w(Khan Chang Valeris Shinzon))]
+      end
+
+      let(:diff_point_phrases) do
+        [phrase('villains', %w(Khan Chang Valeris))]
+      end
+
+      it 'includes the entire array' do
+        expect(diff[:added].size).to eq(0)
+        expect(diff[:modified].size).to eq(1)
+        phrase = diff[:modified].first
+        expect(phrase['key']).to eq('villains')
+        expect(phrase['string']).to eq(%w(Khan Chang Valeris Shinzon))
       end
     end
 

--- a/txgh/spec/merge_calculator_spec.rb
+++ b/txgh/spec/merge_calculator_spec.rb
@@ -46,6 +46,22 @@ describe MergeCalculator do
     end
   end
 
+  context 'with an array added in HEAD' do
+    let(:diff_point_phrases) do
+      [phrase('planet.earth', 'Human')]
+    end
+
+    let(:head_phrases) do
+      diff_point_phrases + [
+        phrase('villains', %w(Kahn Chang Valeris Shinzon))
+      ]
+    end
+
+    it 'includes the added array' do
+      expect(merge_result.phrases).to eq(head_phrases)
+    end
+  end
+
   context 'with phrases removed from HEAD' do
     let(:diff_point_phrases) do
       head_phrases + [
@@ -62,6 +78,22 @@ describe MergeCalculator do
     end
   end
 
+  context 'with an array removed from HEAD' do
+    let(:diff_point_phrases) do
+      head_phrases + [
+        phrase('villains', %w(Kahn Chang Valeris Shinzon))
+      ]
+    end
+
+    let(:head_phrases) do
+      [phrase('planet.earth', 'Human')]
+    end
+
+    it 'does not include the removed array' do
+      expect(merge_result.phrases).to eq(head_phrases)
+    end
+  end
+
   context 'with phrases modified in HEAD' do
     let(:diff_point_phrases) do
       [phrase('planet.bajor', 'Cardassian')]
@@ -69,6 +101,20 @@ describe MergeCalculator do
 
     let(:head_phrases) do
       [phrase('planet.bajor', 'Bajoran')]
+    end
+
+    it 'includes the modified phrase' do
+      expect(merge_result.phrases).to eq(head_phrases)
+    end
+  end
+
+  context 'with an array modified in HEAD' do
+    let(:diff_point_phrases) do
+      [phrase('villains', %w(Kahn Chang Valeris))]
+    end
+
+    let(:head_phrases) do
+      [phrase('villains', %w(Kahn Chang Valeris Shinzon))]
     end
 
     it 'includes the modified phrase' do

--- a/txgh/txgh.gemspec
+++ b/txgh/txgh.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
 
-  s.add_dependency 'abroad', '~> 4.0'
+  s.add_dependency 'abroad', '~> 4.1'
   s.add_dependency 'faraday', '~> 0.9'
   s.add_dependency 'faraday_middleware', '~> 0.10'
   s.add_dependency 'json', '~> 1.8'


### PR DESCRIPTION
Transifex treats arrays as single units. The current system gives each array element its own key, i.e. each array element is treated as a separate string during a diff. If an array element changes, Txgh will fill in the keys that didn't change with `nil`s. Transifex thinks the whole array has changed and saves the translation with the invalid `nil`s.

@lumoslabs/platform 
