### PR TITLE
Use github's contents API for downloading

### DIFF
--- a/txgh/lib/txgh/github_api.rb
+++ b/txgh/lib/txgh/github_api.rb
@@ -91,12 +91,8 @@ module Txgh
 
     def download(repo, path, branch)
       contents = client.contents(repo, { path: path, ref: branch })
-
-      if contents[:encoding] == 'utf-8'
-        contents[:content]
-      else
-        Base64.decode64(contents[:content])
-      end
+      return contents[:content] if contents[:encoding] == 'utf-8'
+      return Base64.decode64(contents[:content])
     end
 
     def create_status(repo, sha, state, options = {})

--- a/txgh/lib/txgh/github_api.rb
+++ b/txgh/lib/txgh/github_api.rb
@@ -90,13 +90,12 @@ module Txgh
     end
 
     def download(repo, path, branch)
-      master = client.ref(repo, branch)
-      commit = client.commit(repo, master[:object][:sha])
-      tree = client.tree(repo, commit[:commit][:tree][:sha], recursive: 1)
+      contents = client.contents(repo, { path: path, ref: branch })
 
-      if found = tree[:tree].find { |t| t[:path] == path }
-        b = blob(repo, found[:sha])
-        b['encoding'] == 'utf-8' ? b['content'] : Base64.decode64(b['content'])
+      if contents[:encoding] == 'utf-8'
+        contents[:content]
+      else
+        Base64.decode64(contents[:content])
       end
     end
 


### PR DESCRIPTION
We're running up against github's maximum tree response size. Use the contents API instead.

@lumoslabs/platform 
