### PR TITLE
Github API Refactor

### DIFF
--- a/txgh/lib/txgh/config/config_pair.rb
+++ b/txgh/lib/txgh/config/config_pair.rb
@@ -28,7 +28,7 @@ module Txgh
 
       def github_api
         @github_api ||= Txgh::GithubApi.create_from_credentials(
-          repo_config['api_username'], repo_config['api_token']
+          repo_config['api_username'], repo_config['api_token'], repo_config['name']
         )
       end
     end

--- a/txgh/lib/txgh/config/providers/git_provider.rb
+++ b/txgh/lib/txgh/config/providers/git_provider.rb
@@ -34,7 +34,7 @@ module Txgh
         private
 
         def download
-          github_repo.api.download(github_repo.name, payload, ref)
+          github_repo.api.download(payload, ref)[:content]
         rescue Octokit::NotFound
           raise Txgh::GitConfigNotFoundError, "Config file #{payload} not found in #{ref}"
         end

--- a/txgh/lib/txgh/github_api.rb
+++ b/txgh/lib/txgh/github_api.rb
@@ -34,7 +34,7 @@ module Txgh
       client.create_ref(repo, branch, sha) rescue false
     end
 
-    def update_contents(repo, branch, content_map, message)
+    def update_contents(branch, content_map, message)
       content_map.each do |path, new_contents|
         branch = Utils.relative_branch(branch)
 
@@ -54,32 +54,6 @@ module Txgh
           )
         end
       end
-    end
-
-    def commit(repo, branch, content_map, message, allow_empty = false)
-      parent = client.ref(repo, branch)
-      base_commit = get_commit(repo, parent[:object][:sha])
-
-      tree_data = content_map.map do |path, content|
-        blob = client.create_blob(repo, content)
-        { path: path, mode: '100644', type: 'blob', sha: blob }
-      end
-
-      tree_options = { base_tree: base_commit[:commit][:tree][:sha] }
-
-      tree = client.create_tree(repo, tree_data, tree_options)
-      commit = client.create_commit(
-        repo, message, tree[:sha], parent[:object][:sha]
-      )
-
-      # don't update the ref if the commit introduced no new changes
-      unless allow_empty
-        diff = client.compare(repo, parent[:object][:sha], commit[:sha])
-        return if diff[:files].empty?
-      end
-
-      # false means don't force push
-      client.update_ref(repo, branch, commit[:sha], false)
     end
 
     def get_commit(sha)

--- a/txgh/lib/txgh/github_api.rb
+++ b/txgh/lib/txgh/github_api.rb
@@ -4,34 +4,34 @@ require 'octokit'
 module Txgh
   class GithubApi
     class << self
-      def create_from_credentials(login, access_token, repo)
+      def create_from_credentials(login, access_token, repo_name)
         create_from_client(
-          Octokit::Client.new(login: login, access_token: access_token), repo
+          Octokit::Client.new(login: login, access_token: access_token), repo_name
         )
       end
 
-      def create_from_client(client, repo)
-        new(client, repo)
+      def create_from_client(client, repo_name)
+        new(client, repo_name)
       end
     end
 
-    attr_reader :client, :repo
+    attr_reader :client, :repo_name
 
-    def initialize(client, repo)
+    def initialize(client, repo_name)
       @client = client
-      @repo = repo
+      @repo_name = repo_name
     end
 
     def tree(sha)
-      client.tree(repo, sha, recursive: 1)
+      client.tree(repo_name, sha, recursive: 1)
     end
 
     def blob(sha)
-      client.blob(repo, sha)
+      client.blob(repo_name, sha)
     end
 
     def create_ref(branch, sha)
-      client.create_ref(repo, branch, sha) rescue false
+      client.create_ref(repo_name, branch, sha) rescue false
     end
 
     def update_contents(branch, content_map, message)
@@ -39,7 +39,7 @@ module Txgh
         branch = Utils.relative_branch(branch)
 
         file = begin
-          client.contents(repo, { path: path, ref: branch })
+          client.contents(repo_name, { path: path, ref: branch })
         rescue Octokit::NotFound
           nil
         end
@@ -50,32 +50,36 @@ module Txgh
 
         if current_sha != new_sha
           client.update_contents(
-            repo, path, message, current_sha, new_contents, options
+            repo_name, path, message, current_sha, new_contents, options
           )
         end
       end
     end
 
     def get_commit(sha)
-      client.commit(repo, sha)
+      client.commit(repo_name, sha)
     end
 
     def get_ref(ref)
-      client.ref(repo, ref)
+      client.ref(repo_name, ref)
     end
 
     def download(path, branch)
-      file = client.contents(repo, { path: path, ref: branch }).to_h
+      file = client.contents(repo_name, { path: path, ref: branch }).to_h
 
-      if file.delete(:encoding) == 'base64'
-        file[:content] = Base64.decode64(file[:content])
+      file[:content] = case file[:encoding]
+        when 'base64'
+          Base64.decode64(file[:content])
+        else
+          file[:content].force_encoding(file[:encoding])
       end
 
+      file.delete(:encoding)
       file
     end
 
     def create_status(sha, state, options = {})
-      client.create_status(repo, sha, state, options)
+      client.create_status(repo_name, sha, state, options)
     end
 
   end

--- a/txgh/lib/txgh/github_api.rb
+++ b/txgh/lib/txgh/github_api.rb
@@ -90,10 +90,10 @@ module Txgh
       client.ref(repo, ref)
     end
 
+    def download(path, branch)
       contents = client.contents(repo, { path: path, ref: branch })
       return contents[:content] if contents[:encoding] == 'utf-8'
       return Base64.decode64(contents[:content])
-    def download(path, branch)
     end
 
     def create_status(sha, state, options = {})

--- a/txgh/lib/txgh/github_api.rb
+++ b/txgh/lib/txgh/github_api.rb
@@ -65,9 +65,13 @@ module Txgh
     end
 
     def download(path, branch)
-      contents = client.contents(repo, { path: path, ref: branch })
-      return contents[:content] if contents[:encoding] == 'utf-8'
-      return Base64.decode64(contents[:content])
+      file = client.contents(repo, { path: path, ref: branch }).to_h
+
+      if file.delete(:encoding) == 'base64'
+        file[:content] = Base64.decode64(file[:content])
+      end
+
+      file
     end
 
     def create_status(sha, state, options = {})

--- a/txgh/lib/txgh/github_api.rb
+++ b/txgh/lib/txgh/github_api.rb
@@ -4,32 +4,33 @@ require 'octokit'
 module Txgh
   class GithubApi
     class << self
-      def create_from_credentials(login, access_token)
+      def create_from_credentials(login, access_token, repo)
         create_from_client(
-          Octokit::Client.new(login: login, access_token: access_token)
+          Octokit::Client.new(login: login, access_token: access_token), repo
         )
       end
 
-      def create_from_client(client)
-        new(client)
+      def create_from_client(client, repo)
+        new(client, repo)
       end
     end
 
-    attr_reader :client
+    attr_reader :client, :repo
 
-    def initialize(client)
+    def initialize(client, repo)
       @client = client
+      @repo = repo
     end
 
-    def tree(repo, sha)
+    def tree(sha)
       client.tree(repo, sha, recursive: 1)
     end
 
-    def blob(repo, sha)
+    def blob(sha)
       client.blob(repo, sha)
     end
 
-    def create_ref(repo, branch, sha)
+    def create_ref(branch, sha)
       client.create_ref(repo, branch, sha) rescue false
     end
 
@@ -81,21 +82,21 @@ module Txgh
       client.update_ref(repo, branch, commit[:sha], false)
     end
 
-    def get_commit(repo, sha)
+    def get_commit(sha)
       client.commit(repo, sha)
     end
 
-    def get_ref(repo, ref)
+    def get_ref(ref)
       client.ref(repo, ref)
     end
 
-    def download(repo, path, branch)
       contents = client.contents(repo, { path: path, ref: branch })
       return contents[:content] if contents[:encoding] == 'utf-8'
       return Base64.decode64(contents[:content])
+    def download(path, branch)
     end
 
-    def create_status(repo, sha, state, options = {})
+    def create_status(sha, state, options = {})
       client.create_status(repo, sha, state, options)
     end
 

--- a/txgh/lib/txgh/github_status.rb
+++ b/txgh/lib/txgh/github_status.rb
@@ -29,7 +29,7 @@ module Txgh
 
     def update(sha)
       repo.api.create_status(
-        repo.name, sha, state, {
+        sha, state, {
           context: context, target_url: target_url, description: description
         }
       )

--- a/txgh/lib/txgh/pusher.rb
+++ b/txgh/lib/txgh/pusher.rb
@@ -19,7 +19,7 @@ module Txgh
     end
 
     def push_resource(tx_resource)
-      ref = repo.api.get_ref(repo.name, branch || repo.branch)
+      ref = repo.api.get_ref(branch || repo.branch)
       updater.update_resource(tx_resource, ref[:object][:sha])
     end
 

--- a/txgh/lib/txgh/resource_committer.rb
+++ b/txgh/lib/txgh/resource_committer.rb
@@ -19,7 +19,7 @@ module Txgh
 
         if translations
           repo.api.update_contents(
-            branch, [{ path: file_name, contents: translations }], message
+            branch, { file_name => translations }, message
           )
 
           fire_event_for(tx_resource, branch, language)

--- a/txgh/lib/txgh/resource_committer.rb
+++ b/txgh/lib/txgh/resource_committer.rb
@@ -19,7 +19,7 @@ module Txgh
 
         if translations
           repo.api.update_contents(
-            repo.name, branch, { file_name => translations }, message
+            branch, [{ path: file_name, contents: translations }], message
           )
 
           fire_event_for(tx_resource, branch, language)
@@ -30,7 +30,7 @@ module Txgh
     private
 
     def fire_event_for(tx_resource, branch, language)
-      head = repo.api.get_ref(repo.name, branch)
+      head = repo.api.get_ref(branch)
       sha = head[:object][:sha]
 
       Txgh.events.publish(

--- a/txgh/lib/txgh/resource_updater.rb
+++ b/txgh/lib/txgh/resource_updater.rb
@@ -12,7 +12,7 @@ module Txgh
       @logger = logger || Logger.new(STDOUT)
     end
 
-    def update_resource(tx_resource, branch, categories = {})
+    def update_resource(tx_resource, commit_sha, categories = {})
       # don't process the resource unless the project slugs are the same
       return unless tx_resource.project_slug == project.name
 

--- a/txgh/lib/txgh/resource_updater.rb
+++ b/txgh/lib/txgh/resource_updater.rb
@@ -12,15 +12,13 @@ module Txgh
       @logger = logger || Logger.new(STDOUT)
     end
 
-    # For each modified resource, get its content and update the content
-    # in Transifex.
-    def update_resource(tx_resource, commit_sha, categories = {})
+    def update_resource(tx_resource, branch, categories = {})
       # don't process the resource unless the project slugs are the same
       return unless tx_resource.project_slug == project.name
 
       logger.info('process updated resource')
-      tree_sha = repo.api.get_commit(repo.name, commit_sha)['commit']['tree']['sha']
-      tree = repo.api.tree(repo.name, tree_sha)
+      tree_sha = repo.api.get_commit(commit_sha)['commit']['tree']['sha']
+      tree = repo.api.tree(tree_sha)
 
       tree['tree'].each do |file|
         logger.info("process each tree entry: #{file['path']}")
@@ -81,7 +79,7 @@ module Txgh
     end
 
     def diff_point_content(tx_resource, file)
-      raw_content = repo.api.download(repo.name, file['path'], repo.diff_point)
+      raw_content = repo.api.download(file['path'], repo.diff_point)
       ResourceContents.from_string(tx_resource, raw_content)
     end
 
@@ -110,7 +108,7 @@ module Txgh
     end
 
     def contents_of(sha)
-      blob = repo.api.blob(repo.name, sha)
+      blob = repo.api.blob(sha)
 
       if blob['encoding'] == 'utf-8'
         blob['content']

--- a/txgh/spec/config/tx_manager_spec.rb
+++ b/txgh/spec/config/tx_manager_spec.rb
@@ -40,7 +40,7 @@ describe TxManager do
         expect(repo.api).to(
           receive(:download)
             .with('./tx.config', 'my_branch')
-            .and_return("[main]\nlang_map = ko:ko_KR")
+            .and_return(content: "[main]\nlang_map = ko:ko_KR")
         )
 
         config = TxManager.tx_config(project, repo, 'my_branch')

--- a/txgh/spec/config/tx_manager_spec.rb
+++ b/txgh/spec/config/tx_manager_spec.rb
@@ -39,7 +39,7 @@ describe TxManager do
       it 'loads tx config from a git repository' do
         expect(repo.api).to(
           receive(:download)
-            .with(repo.name, './tx.config', 'my_branch')
+            .with('./tx.config', 'my_branch')
             .and_return("[main]\nlang_map = ko:ko_KR")
         )
 

--- a/txgh/spec/github_api_spec.rb
+++ b/txgh/spec/github_api_spec.rb
@@ -12,21 +12,21 @@ describe GithubApi do
 
   describe '#tree' do
     it 'retrieves a git tree using the client' do
-      expect(client).to receive(:tree).with(sha, recursive: 1)
+      expect(client).to receive(:tree).with(repo, sha, recursive: 1)
       api.tree(sha)
     end
   end
 
   describe '#blob' do
     it 'retrieves a git blob using the client' do
-      expect(client).to receive(:blob).with(sha)
+      expect(client).to receive(:blob).with(repo, sha)
       api.blob(sha)
     end
   end
 
   describe '#create_ref' do
     it 'creates the given ref using the client' do
-      expect(client).to receive(:create_ref).with(branch, sha)
+      expect(client).to receive(:create_ref).with(repo, branch, sha)
       api.create_ref(branch, sha)
     end
 
@@ -46,13 +46,13 @@ describe GithubApi do
 
       expect(client).to(
         receive(:contents)
-          .with({ ref: branch, path: path })
+          .with(repo, { ref: branch, path: path })
           .and_return({ sha: old_sha, content: Base64.encode64(old_contents) })
       )
 
       expect(client).to(
         receive(:update_contents)
-          .with(path, 'message', old_sha, new_contents, { branch: branch })
+          .with(repo, path, 'message', old_sha, new_contents, { branch: branch })
       )
 
       api.update_contents(branch, { path => new_contents }, 'message')
@@ -61,7 +61,7 @@ describe GithubApi do
     it "doesn't update the file contents if the file hasn't changed" do
       expect(client).to(
         receive(:contents)
-          .with({ ref: branch, path: path })
+          .with(repo, { ref: branch, path: path })
           .and_return({ sha: old_sha, content: Base64.encode64(old_contents) })
       )
 
@@ -78,7 +78,7 @@ describe GithubApi do
 
       expect(client).to(
         receive(:update_contents)
-          .with(path, 'message', '0' * 40, new_contents, { branch: branch })
+          .with(repo, path, 'message', '0' * 40, new_contents, { branch: branch })
       )
 
       api.update_contents(branch, { path => new_contents }, 'message')
@@ -87,14 +87,14 @@ describe GithubApi do
 
   describe '#get_commit' do
     it 'retrieves the given commit using the client' do
-      expect(client).to receive(:commit).with(sha)
+      expect(client).to receive(:commit).with(repo, sha)
       api.get_commit(sha)
     end
   end
 
   describe '#get_ref' do
     it 'retrieves the given ref (i.e. branch) using the client' do
-      expect(client).to receive(:ref).with(sha)
+      expect(client).to receive(:ref).with(repo, sha)
       api.get_ref(sha)
     end
   end
@@ -105,7 +105,7 @@ describe GithubApi do
     it 'downloads the file from the given branch' do
       expect(client).to(
         receive(:contents)
-          .with(path: path, ref: branch)
+          .with(repo, path: path, ref: branch)
           .and_return(
             content: 'content', encoding: 'utf-8'
           )
@@ -117,7 +117,7 @@ describe GithubApi do
     it 'automatically decodes base64-encoded content' do
       expect(client).to(
         receive(:contents)
-          .with(path: path, ref: branch)
+          .with(repo, path: path, ref: branch)
           .and_return(
             content: Base64.encode64('content'), encoding: 'base64'
           )

--- a/txgh/spec/github_api_spec.rb
+++ b/txgh/spec/github_api_spec.rb
@@ -5,34 +5,34 @@ include Txgh
 
 describe GithubApi do
   let(:client) { double(:client) }
-  let(:api) { GithubApi.create_from_client(client) }
+  let(:api) { GithubApi.create_from_client(client, repo) }
   let(:repo) { 'my_org/my_repo' }
   let(:branch) { 'master' }
   let(:sha) { 'abc123' }
 
   describe '#tree' do
     it 'retrieves a git tree using the client' do
-      expect(client).to receive(:tree).with(repo, sha, recursive: 1)
-      api.tree(repo, sha)
+      expect(client).to receive(:tree).with(sha, recursive: 1)
+      api.tree(sha)
     end
   end
 
   describe '#blob' do
     it 'retrieves a git blob using the client' do
-      expect(client).to receive(:blob).with(repo, sha)
-      api.blob(repo, sha)
+      expect(client).to receive(:blob).with(sha)
+      api.blob(sha)
     end
   end
 
   describe '#create_ref' do
     it 'creates the given ref using the client' do
-      expect(client).to receive(:create_ref).with(repo, branch, sha)
-      api.create_ref(repo, branch, sha)
+      expect(client).to receive(:create_ref).with(branch, sha)
+      api.create_ref(branch, sha)
     end
 
     it 'returns false on client error' do
       expect(client).to receive(:create_ref).and_raise(StandardError)
-      expect(api.create_ref(repo, branch, sha)).to eq(false)
+      expect(api.create_ref(branch, sha)).to eq(false)
     end
   end
 
@@ -46,28 +46,28 @@ describe GithubApi do
 
       expect(client).to(
         receive(:contents)
-          .with(repo, { ref: branch, path: path })
+          .with({ ref: branch, path: path })
           .and_return({ sha: old_sha, content: Base64.encode64(old_contents) })
       )
 
       expect(client).to(
         receive(:update_contents)
-          .with(repo, path, 'message', old_sha, new_contents, { branch: branch })
+          .with(path, 'message', old_sha, new_contents, { branch: branch })
       )
 
-      api.update_contents(repo, branch, { path => new_contents }, 'message')
+      api.update_contents(branch, { path => new_contents }, 'message')
     end
 
     it "doesn't update the file contents if the file hasn't changed" do
       expect(client).to(
         receive(:contents)
-          .with(repo, { ref: branch, path: path })
+          .with({ ref: branch, path: path })
           .and_return({ sha: old_sha, content: Base64.encode64(old_contents) })
       )
 
       expect(client).to_not receive(:update_contents)
 
-      api.update_contents(repo, branch, { path => old_contents }, 'message')
+      api.update_contents(branch, { path => old_contents }, 'message')
     end
 
     it "creates the file if it doesn't already exist" do
@@ -78,103 +78,24 @@ describe GithubApi do
 
       expect(client).to(
         receive(:update_contents)
-          .with(repo, path, 'message', '0' * 40, new_contents, { branch: branch })
+          .with(path, 'message', '0' * 40, new_contents, { branch: branch })
       )
 
-      api.update_contents(repo, branch, { path => new_contents }, 'message')
-    end
-  end
-
-  describe '#commit' do
-    let(:path) { 'path/to/translations' }
-    let(:other_path) { 'other/path/to/translations' }
-
-    before(:each) do
-      allow(client).to receive(:create_blob).with(repo, :new_content).and_return(:blob_sha)
-      allow(client).to receive(:ref).with(repo, branch).and_return(object: { sha: :branch_sha })
-      allow(client).to receive(:commit).with(repo, :branch_sha).and_return(commit: { tree: { sha: :base_tree_sha } })
-      allow(client).to receive(:create_tree).and_return(sha: :new_tree_sha)
-    end
-
-    it 'creates a new commit and updates the branch' do
-      expect(client).to(
-        receive(:create_commit)
-          .with(repo, 'message', :new_tree_sha, :branch_sha)
-          .and_return(sha: :new_commit_sha)
-      )
-
-      expect(client).to receive(:update_ref).with(repo, branch, :new_commit_sha, false)
-      api.commit(repo, branch, { path => :new_content }, 'message', true)
-    end
-
-    it 'updates multiple files at a time' do
-      allow(client).to receive(:create_blob).with(repo, :other_content).and_return(:blob_sha_2)
-
-      expect(client).to(
-        receive(:create_commit)
-          .with(repo, 'message', :new_tree_sha, :branch_sha)
-          .and_return(sha: :new_commit_sha)
-      )
-
-      expect(client).to receive(:update_ref).with(repo, branch, :new_commit_sha, false)
-      content_map = { path => :new_content, other_path => :other_content }
-      api.commit(repo, branch, content_map, 'message', true)
-    end
-
-    context 'with an empty commit' do
-      before(:each) do
-        allow(client).to(
-          receive(:compare)
-            .with(repo, :branch_sha, :new_commit_sha)
-            .and_return(files: [])
-        )
-
-        expect(client).to(
-          receive(:create_commit)
-            .with(repo, 'message', :new_tree_sha, :branch_sha)
-            .and_return(sha: :new_commit_sha)
-        )
-      end
-
-      it 'does not allow empty commits by default' do
-        expect(client).to_not receive(:update_ref)
-        api.commit(repo, branch, { path => :new_content }, 'message')
-      end
-    end
-
-    context 'with a non-empty commit' do
-      before(:each) do
-        allow(client).to(
-          receive(:compare)
-            .with(repo, :branch_sha, :new_commit_sha)
-            .and_return(files: %w(abc def))
-        )
-
-        expect(client).to(
-          receive(:create_commit)
-            .with(repo, 'message', :new_tree_sha, :branch_sha)
-            .and_return(sha: :new_commit_sha)
-        )
-      end
-
-      it 'updates the ref as expected' do
-        expect(client).to receive(:update_ref).with(repo, branch, :new_commit_sha, false)
-        api.commit(repo, branch, { path => :new_content }, 'message')
-      end
+      api.update_contents(branch, { path => new_contents }, 'message')
     end
   end
 
   describe '#get_commit' do
     it 'retrieves the given commit using the client' do
-      expect(client).to receive(:commit).with(repo, sha)
-      api.get_commit(repo, sha)
+      expect(client).to receive(:commit).with(sha)
+      api.get_commit(sha)
     end
   end
 
   describe '#get_ref' do
     it 'retrieves the given ref (i.e. branch) using the client' do
-      expect(client).to receive(:ref).with(repo, sha)
-      api.get_ref(repo, sha)
+      expect(client).to receive(:ref).with(sha)
+      api.get_ref(sha)
     end
   end
 
@@ -184,25 +105,25 @@ describe GithubApi do
     it 'downloads the file from the given branch' do
       expect(client).to(
         receive(:contents)
-          .with(repo, path: path, ref: branch)
+          .with(path: path, ref: branch)
           .and_return(
             content: 'content', encoding: 'utf-8'
           )
       )
 
-      expect(api.download(repo, path, branch)).to eq('content')
+      expect(api.download(path, branch)).to eq('content')
     end
 
     it 'automatically decodes base64-encoded content' do
       expect(client).to(
         receive(:contents)
-          .with(repo, path: path, ref: branch)
+          .with(path: path, ref: branch)
           .and_return(
             content: Base64.encode64('content'), encoding: 'base64'
           )
       )
 
-      expect(api.download(repo, path, branch)).to eq('content')
+      expect(api.download(path, branch)).to eq('content')
     end
   end
 end

--- a/txgh/spec/github_api_spec.rb
+++ b/txgh/spec/github_api_spec.rb
@@ -111,7 +111,23 @@ describe GithubApi do
           )
       )
 
-      expect(api.download(path, branch)).to eq('content')
+      expect(api.download(path, branch)).to eq({ content: 'content' })
+    end
+
+    it 'encodes the string using the encoding specified in the response' do
+      content = 'ありがと'.encode('UTF-16')
+
+      expect(client).to(
+        receive(:contents)
+          .with(repo, path: path, ref: branch)
+          .and_return(
+            content: content, encoding: 'utf-16'
+          )
+      )
+
+      result = api.download(path, branch)
+      expect(result[:content].encoding).to eq(Encoding::UTF_16)
+      expect(result[:content]).to eq(content)
     end
 
     it 'automatically decodes base64-encoded content' do
@@ -123,7 +139,7 @@ describe GithubApi do
           )
       )
 
-      expect(api.download(path, branch)).to eq('content')
+      expect(api.download(path, branch)).to eq({ content: 'content' })
     end
   end
 end

--- a/txgh/spec/github_status_spec.rb
+++ b/txgh/spec/github_status_spec.rb
@@ -26,8 +26,7 @@ describe GithubStatus do
 
     context 'with all resources at 100%' do
       it 'reports status as success' do
-        expect(github_api).to receive(:create_status) do |repo, commit_sha, state, options|
-          expect(repo).to eq(repo_name)
+        expect(github_api).to receive(:create_status) do |commit_sha, state, options|
           expect(commit_sha).to eq(sha)
           expect(state).to eq(GithubStatus::State.success)
           expect(options[:description]).to eq('Translations complete!')
@@ -56,7 +55,7 @@ describe GithubStatus do
       end
 
       it 'reports status as pending' do
-        expect(github_api).to receive(:create_status) do |repo, commit_sha, state, options|
+        expect(github_api).to receive(:create_status) do |commit_sha, state, options|
           expect(state).to eq(GithubStatus::State.pending)
           expect(options[:description]).to eq('15/20 translations complete.')
         end

--- a/txgh/spec/resource_committer_spec.rb
+++ b/txgh/spec/resource_committer_spec.rb
@@ -32,7 +32,7 @@ describe ResourceCommitter do
 
         expect(github_api).to(
           receive(:update_contents).with(
-            repo_name, branch, { file_name => :translations }, commit_message
+            branch, [{ path: file_name, contents: :translations }], commit_message
           )
         )
       end

--- a/txgh/spec/resource_committer_spec.rb
+++ b/txgh/spec/resource_committer_spec.rb
@@ -32,7 +32,7 @@ describe ResourceCommitter do
 
         expect(github_api).to(
           receive(:update_contents).with(
-            branch, [{ path: file_name, contents: :translations }], commit_message
+            branch, { file_name => :translations }, commit_message
           )
         )
       end

--- a/txgh/spec/resource_updater_spec.rb
+++ b/txgh/spec/resource_updater_spec.rb
@@ -32,20 +32,20 @@ describe ResourceUpdater do
     tree_sha = 'abc123'
 
     allow(github_api).to(
-      receive(:get_commit).with(repo_name, commit_sha) do
+      receive(:get_commit).with(commit_sha) do
         { 'commit' => { 'tree' => { 'sha' => tree_sha } } }
       end
     )
 
     allow(github_api).to(
-      receive(:tree).with(repo_name, tree_sha) do
+      receive(:tree).with(tree_sha) do
         { 'tree' => modified_files }
       end
     )
 
     modified_files.each do |file|
       allow(github_api).to(
-        receive(:blob).with(repo_name, file['sha']) do
+        receive(:blob).with(file['sha']) do
           { 'content' => translations, 'encoding' => 'utf-8' }
         end
       )
@@ -134,7 +134,7 @@ describe ResourceUpdater do
     it 'uploads a diff instead of the whole resource' do
       expect(github_api).to(
         receive(:download)
-          .with(repo_name, 'en.yml', diff_point)
+          .with('en.yml', diff_point)
           .and_return(YAML.load("|
             en:
               welcome: Hello


### PR DESCRIPTION
I realized we were passing in the repo name everywhere, so why not make it an instance var? Also, we're not using `GithubApi#commit` anymore.

@lumoslabs/platform 
