### PR TITLE
Add github event to webhook attribute classes

### DIFF
--- a/server/lib/txgh-server/webhooks/github/delete_attributes.rb
+++ b/server/lib/txgh-server/webhooks/github/delete_attributes.rb
@@ -3,7 +3,7 @@ module TxghServer
     module Github
       class DeleteAttributes
         ATTRIBUTES = [
-          :repo_name, :ref, :ref_type
+          :event, :repo_name, :ref, :ref_type
         ]
 
         class << self
@@ -13,6 +13,10 @@ module TxghServer
                 ret[attr] = public_send(attr, payload)
               end
             )
+          end
+
+          def event(payload)
+            'delete'
           end
 
           def repo_name(payload)

--- a/server/lib/txgh-server/webhooks/github/push_attributes.rb
+++ b/server/lib/txgh-server/webhooks/github/push_attributes.rb
@@ -1,11 +1,9 @@
-require 'set'
-
 module TxghServer
   module Webhooks
     module Github
       class PushAttributes
         ATTRIBUTES = [
-          :repo_name, :ref, :before, :after,
+          :event, :repo_name, :ref, :before, :after,
           :added_files, :modified_files, :author
         ]
 
@@ -16,6 +14,10 @@ module TxghServer
                 ret[attr] = public_send(attr, payload)
               end
             )
+          end
+
+          def event(payload)
+            'push'
           end
 
           def repo_name(payload)


### PR DESCRIPTION
Adds the github event to the webhook attribute classes. Useful for the queue work I'm doing.

@lumoslabs/platform 
