### PR TITLE
Publish error params

### DIFF
--- a/server/lib/txgh-server/application.rb
+++ b/server/lib/txgh-server/application.rb
@@ -15,8 +15,7 @@ module TxghServer
           begin
             resp.write_to(out)
           rescue => e
-            Txgh.events.publish_error(e)
-            raise e
+            Txgh.events.publish_error!(e)
           end
         end
       else

--- a/txgh/lib/txgh/events.rb
+++ b/txgh/lib/txgh/events.rb
@@ -24,10 +24,16 @@ module Txgh
       channel_hash.keys
     end
 
-    def publish_error(e)
+    def publish_error(e, options = {})
       # if nobody has subscribed to error events, raise original error
-      callbacks = channel_hash.fetch(ERROR_CHANNEL) { raise e }
-      callbacks.each { |callback| callback.call(e) }
+      callbacks = channel_hash.fetch(ERROR_CHANNEL) do
+        raise(e) if options.fetch(:raise_if_no_subscribers, true)
+        []
+      end
+
+      callbacks.map do |callback|
+        callback.call(e, options.fetch(:params, {}))
+      end
     end
   end
 end

--- a/txgh/lib/txgh/events.rb
+++ b/txgh/lib/txgh/events.rb
@@ -17,23 +17,22 @@ module Txgh
         callback.call(options)
       end
     rescue => e
-      publish_error(e)
+      publish_error!(e)
     end
 
     def channels
       channel_hash.keys
     end
 
-    def publish_error(e, options = {})
-      # if nobody has subscribed to error events, raise original error
-      callbacks = channel_hash.fetch(ERROR_CHANNEL) do
-        raise(e) if options.fetch(:raise_if_no_subscribers, true)
-        []
-      end
+    def publish_error(e, params = {})
+      callbacks = channel_hash.fetch(ERROR_CHANNEL) { [] }
+      callbacks.map { |callback| callback.call(e, params) }
+    end
 
-      callbacks.map do |callback|
-        callback.call(e, options.fetch(:params, {}))
-      end
+    def publish_error!(e, params = {})
+      # if nobody has subscribed to error events, raise original error
+      callbacks = channel_hash.fetch(ERROR_CHANNEL) { raise e }
+      callbacks.map { |callback| callback.call(e, params) }
     end
   end
 end

--- a/txgh/spec/events_spec.rb
+++ b/txgh/spec/events_spec.rb
@@ -51,5 +51,24 @@ describe Events do
       expect(errors.size).to eq(1)
       expect(errors.first.message).to eq('foo')
     end
+
+    it 'includes additional params' do
+      errors = []
+      events.subscribe('errors') { |e, params| errors << { error: e, params: params } }
+      events.publish_error(begin; raise 'foo'; rescue => e; e; end, params: { foo: 'bar' })
+      expect(errors.size).to eq(1)
+
+      error = errors.first
+      expect(error[:error].message).to eq('foo')
+      expect(error[:params]).to eq(foo: 'bar')
+    end
+
+    it 'raises errors if no error subscribers are configured' do
+      expect { events.publish_error(StandardError.new) }.to raise_error(StandardError)
+    end
+
+    it 'does not raise errors if specifically asked not to when no error subscribers are configured' do
+      expect { events.publish_error(StandardError.new, raise_if_no_subscribers: false) }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
Provide the ability to include a set of extra parameters to include when publishing errors on Txgh's event system.

@lumoslabs/platform
