### PR TITLE
Fix issue trying to call .fetch on nil

### DIFF
--- a/server/lib/txgh-server/webhooks/github/push_attributes.rb
+++ b/server/lib/txgh-server/webhooks/github/push_attributes.rb
@@ -45,7 +45,12 @@ module TxghServer
           end
 
           def author(payload)
-            payload.fetch('head_commit').fetch('committer').fetch('name')
+            if head_commit = payload.fetch('head_commit')
+              head_commit.fetch('committer').fetch('name')
+            else
+              # fall back to pusher if no head commit
+              payload.fetch('pusher').fetch('name')
+            end
           end
 
           def extract_files(payload, state)

--- a/server/spec/helpers/github_payload_builder.rb
+++ b/server/spec/helpers/github_payload_builder.rb
@@ -22,7 +22,11 @@ class GithubPayload
     @result.to_json
   end
 
-  protected
+  def merge!(hash)
+    @result.merge!(hash)
+  end
+
+  private
 
   def digits
     @@digits ||= ('a'..'f').to_a + ('0'..'9').to_a
@@ -92,6 +96,7 @@ class GithubPushPayload < GithubPayload
       deleted: false,
       forced: true,
       base_ref: nil,
+      head_commit: nil,
       compare: "https://github.com/#{@repo}/commit/#{@after[0..12]}",
       commits: [],
       repository: {

--- a/server/spec/webhooks/github/push_attributes_spec.rb
+++ b/server/spec/webhooks/github/push_attributes_spec.rb
@@ -11,44 +11,57 @@ describe PushAttributes do
   let(:modified) { ['modified_file.txt'] }
 
   let(:payload) do
-    GithubPayloadBuilder.push_payload(repo_name, ref).tap do |payload|
-      payload.add_commit(added: added, modified: modified)
-    end
+    GithubPayloadBuilder.push_payload(repo_name, ref)
   end
 
   describe '#from_webhook_payload' do
     let(:attributes) { PushAttributes.from_webhook_payload(payload.to_h) }
 
-    it 'pulls out repo name' do
-      expect(attributes.repo_name).to eq(repo_name)
+    it "when no head commit, uses the pusher's name instead" do
+      payload.merge!(pusher: { name: 'Fu Barro', email: 'fu@barro.com' })
+      expect(attributes.author).to eq('Fu Barro')
+    end
+  end
+
+  context 'with a commit added to the payload' do
+    before(:each) do
+      payload.add_commit(added: added, modified: modified)
     end
 
-    it 'pulls out ref' do
-      expect(attributes.ref).to eq("refs/#{ref}")
-    end
+    describe '#from_webhook_payload' do
+      let(:attributes) { PushAttributes.from_webhook_payload(payload.to_h) }
 
-    it 'pulls out before sha' do
-      expect(attributes.before).to eq(payload.to_h['before'])
-    end
+      it 'pulls out repo name' do
+        expect(attributes.repo_name).to eq(repo_name)
+      end
 
-    it 'pulls out after sha' do
-      expect(attributes.after).to eq(payload.to_h['after'])
-    end
+      it 'pulls out ref' do
+        expect(attributes.ref).to eq("refs/#{ref}")
+      end
 
-    it 'pulls out added files' do
-      expect(attributes.added_files.to_a).to eq(added)
-    end
+      it 'pulls out before sha' do
+        expect(attributes.before).to eq(payload.to_h['before'])
+      end
 
-    it 'pulls out modified files' do
-      expect(attributes.modified_files.to_a).to eq(modified)
-    end
+      it 'pulls out after sha' do
+        expect(attributes.after).to eq(payload.to_h['after'])
+      end
 
-    it 'combines all files into one handy array' do
-      expect(attributes.files.sort).to eq((added + modified).sort)
-    end
+      it 'pulls out added files' do
+        expect(attributes.added_files.to_a).to eq(added)
+      end
 
-    it 'pulls out the author' do
-      expect(attributes.author).to eq('Test User')
+      it 'pulls out modified files' do
+        expect(attributes.modified_files.to_a).to eq(modified)
+      end
+
+      it 'combines all files into one handy array' do
+        expect(attributes.files.sort).to eq((added + modified).sort)
+      end
+
+      it 'pulls out the author' do
+        expect(attributes.author).to eq('Test User')
+      end
     end
   end
 end


### PR DESCRIPTION
https://rollbar.com/lumoslabs/txgh/items/115/

Github sends two events when a branch is deleted: a push event where the `after` commit is 40 zeroes, and a delete event. Txgh cleans up old resources when it receives the delete event, and basically ignores the corresponding push event. However, our `PushAttributes` class expects push payloads to always have a `head_commit` attribute, which deleted pushes don't have. This PR fixes the issue by falling back to the `pusher` attribute.

@lumoslabs/platform 
