### PR TITLE
Don't fail if the response code is in the 300 range

### DIFF
--- a/queue/lib/txgh-queue/error_handlers/server_response.rb
+++ b/queue/lib/txgh-queue/error_handlers/server_response.rb
@@ -10,7 +10,7 @@ module TxghQueue
 
         def status_for(response)
           case response.status.to_i / 100
-            when 2
+            when 2, 3
               Status.ok
             else
               Status.fail

--- a/queue/spec/error_handlers/server_response_spec.rb
+++ b/queue/spec/error_handlers/server_response_spec.rb
@@ -21,6 +21,12 @@ describe ErrorHandlers::ServerResponse do
       expect(reply).to eq(Status.ok)
     end
 
+    it 'replies with ok if the status code is in the 300 range' do
+      server_response = TxghServer::Response.new(304, 'Not modified')
+      reply = described_class.status_for(server_response)
+      expect(reply).to eq(Status.ok)
+    end
+
     it 'replies with fail if the status code is in the 400 range' do
       server_response = TxghServer::Response.new(404, 'Not found')
       reply = described_class.status_for(server_response)


### PR DESCRIPTION
Txgh will return a 304 if Transifex tells it to pull English translations (which is non-sensical).

@lumoslabs/platform 
