### PR TITLE
Add text support

### DIFF
--- a/txgh/History.txt
+++ b/txgh/History.txt
@@ -1,3 +1,6 @@
+== 6.2.0
+* Add support for text files.
+
 == 6.1.2
 * Handle Octokit::NotFound when downloading from Github.
 

--- a/txgh/lib/txgh/resource_contents.rb
+++ b/txgh/lib/txgh/resource_contents.rb
@@ -7,14 +7,16 @@ module Txgh
       'YML'          => 'yaml/rails',
       'YAML'         => 'yaml/rails',
       'KEYVALUEJSON' => 'json/key-value',
-      'ANDROID'      => 'xml/android'
+      'ANDROID'      => 'xml/android',
+      'TXT'          => 'txt/lines'
     }
 
     SERIALIZER_MAP = {
       'YML'          => 'yaml/rails',
       'YAML'         => 'yaml/rails',
       'KEYVALUEJSON' => 'json/key-value',
-      'ANDROID'      => 'xml/android'
+      'ANDROID'      => 'xml/android',
+      'TXT'          => 'txt/lines'
     }
 
     class << self

--- a/txgh/lib/txgh/version.rb
+++ b/txgh/lib/txgh/version.rb
@@ -1,3 +1,3 @@
 module Txgh
-  VERSION = '6.1.2'
+  VERSION = '6.2.0'
 end

--- a/txgh/txgh.gemspec
+++ b/txgh/txgh.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
 
-  s.add_dependency 'abroad', '~> 4.1'
+  s.add_dependency 'abroad', '~> 4.2'
   s.add_dependency 'celluloid'
   s.add_dependency 'faraday', '~> 0.9'
   s.add_dependency 'faraday_middleware', '~> 0.10'


### PR DESCRIPTION
For the iOS app store strings in [this repo](https://github.com/lumoslabs/AppStoreLocalization). Note that tests won't pass until [abroad v4.2.0](https://github.com/camertron/abroad/pull/2) is published.

@lumoslabs/platform, heads up @bkobilansky 