### PR TITLE
Fix case when categories are empty

### DIFF
--- a/txgh/lib/txgh/resource_deleter.rb
+++ b/txgh/lib/txgh/resource_deleter.rb
@@ -20,7 +20,7 @@ module Txgh
 
     def tx_resources
       project.api.get_resources(project.name).map do |resource_hash|
-        categories = deserialize_categories(resource_hash['categories'])
+        categories = deserialize_categories(resource_hash['categories'] || [])
         resource_branch = Txgh::Utils.absolute_branch(categories['branch'])
 
         if resource_branch == branch

--- a/txgh/spec/resource_deleter_spec.rb
+++ b/txgh/spec/resource_deleter_spec.rb
@@ -36,6 +36,14 @@ describe ResourceDeleter do
     deleter.delete_resources
   end
 
+  it 'handles the case when no categories are present' do
+    expect(transifex_api).to(
+      receive(:get_resources).and_return([resource.to_api_h.merge('categories' => nil)])
+    )
+
+    expect { deleter.delete_resources }.to_not raise_error
+  end
+
   it "does not delete resources that don't have a matching branch" do
     deleter = ResourceDeleter.new(transifex_project, github_repo, 'heads/fake')
     expect(transifex_api).to(


### PR DESCRIPTION
[PLAT-1355](https://lumoslabs.atlassian.net/browse/PLAT-1355)

Fixes the case when the categories array is `nil`, i.e. not an array.

See: https://rollbar.com/lumoslabs/txgh/items/174/occurrences/18915362130/

@lumoslabs/platform 