### PR TITLE
Support new Transifex auth strategy

### DIFF
--- a/queue/History.txt
+++ b/queue/History.txt
@@ -1,3 +1,6 @@
+== 2.0.0
+* Upgrade to txgh-server 3.0 to conform to new Transifex auth strategy.
+
 == 1.1.0
 * Retry on network errors from Net::Protocol and Faraday.
 

--- a/queue/lib/txgh-queue/version.rb
+++ b/queue/lib/txgh-queue/version.rb
@@ -1,3 +1,3 @@
 module TxghQueue
-  VERSION = '1.1.0'
+  VERSION = '2.0.0'
 end

--- a/queue/spec/webhooks/transifex/request_handler_spec.rb
+++ b/queue/spec/webhooks/transifex/request_handler_spec.rb
@@ -10,7 +10,7 @@ describe Transifex::RequestHandler, auto_configure: true do
   include StandardTxghSetup
 
   let(:logger) { NilLogger.new }
-  let(:body) { URI.encode_www_form(payload.to_a) }
+  let(:body) { payload.to_json }
   let(:request) { TestRequest.new(body: body) }
   let(:handler) { described_class.new(request, logger) }
   let(:payload) do
@@ -42,7 +42,7 @@ describe Transifex::RequestHandler, auto_configure: true do
       end
 
       let(:backend) { TxghQueue::Config.backend }
-      let(:producer) { backend.producer_for("transifex.hook") }
+      let(:producer) { backend.producer_for('transifex.hook') }
 
       it 'does not enqueue if unauthorized' do
         expect { handler.handle_request }.to_not(

--- a/queue/txgh-queue.gemspec
+++ b/queue/txgh-queue.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'aws-sdk', '~> 2.0'
   s.add_dependency 'txgh', '~> 6.0'
-  s.add_dependency 'txgh-server', '~> 2.2'
+  s.add_dependency 'txgh-server', '~> 3.0'
   s.add_dependency 'sinatra', '~> 1.4'
   s.add_dependency 'sinatra-contrib', '~> 1.4'
 

--- a/server/History.txt
+++ b/server/History.txt
@@ -1,3 +1,6 @@
+== 3.0.0
+* Conform to new Transifex auth strategy they didn't tell anybody about.
+
 == 2.4.0
 * Publish event upon receiving Transifex webhook.
 

--- a/server/lib/txgh-server/github_request_auth.rb
+++ b/server/lib/txgh-server/github_request_auth.rb
@@ -9,12 +9,12 @@ module TxghServer
     class << self
       def authentic_request?(request, secret)
         request.body.rewind
-        expected_signature = header_value(request.body.read, secret)
+        expected_signature = compute_signature(request.body.read, secret)
         actual_signature = request.env[RACK_HEADER]
         actual_signature == expected_signature
       end
 
-      def header_value(content, secret)
+      def compute_signature(content, secret)
         "sha1=#{digest(content, secret)}"
       end
 

--- a/server/lib/txgh-server/version.rb
+++ b/server/lib/txgh-server/version.rb
@@ -1,3 +1,3 @@
 module TxghServer
-  VERSION = '2.4.0'
+  VERSION = '3.0.0'
 end

--- a/server/spec/github_request_auth_spec.rb
+++ b/server/spec/github_request_auth_spec.rb
@@ -30,9 +30,9 @@ describe GithubRequestAuth do
     end
   end
 
-  describe '.header' do
+  describe '.compute_signature' do
     it 'calculates the signature and formats it as an http header' do
-      value = GithubRequestAuth.header_value(params, secret)
+      value = GithubRequestAuth.compute_signature(params, secret)
       expect(value).to eq("sha1=#{valid_signature}")
     end
   end

--- a/server/spec/helpers/test_request.rb
+++ b/server/spec/helpers/test_request.rb
@@ -1,10 +1,11 @@
 class TestRequest
-  attr_reader :body, :params, :headers
+  attr_reader :body, :params, :headers, :request_method
   alias_method :env, :headers
 
-  def initialize(body: , params: {}, headers: {})
+  def initialize(body: , params: {}, headers: {}, request_method: 'POST')
     @body = StringIO.new(body)
     @params = params
     @headers = headers
+    @request_method = request_method
   end
 end


### PR DESCRIPTION
According to their [docs](https://docs.transifex.com/integrations/webhooks), Transifex uses a different way of signing webhook requests nowadays. Apparently they switched in February of 2017 but didn't tell anybody 😠 

The major changes are these:
* Parameters are JSON encoded instead of URL form encoded.
* They've done away with the ridiculous Python map thing.
* The signature is computed now with the HTTP verb, date string (via the `HTTP_DATE` header), webhook URL, and request body (used to be just the request body).
* The signature is computed using SHA256 instead of SHA1.

NOTE: The tests for txgh-queue will not pass until txgh-server v3.0 is published.