### PR TITLE
 Support form-encoded Transifex payloads

### DIFF
--- a/queue/spec/application_spec.rb
+++ b/queue/spec/application_spec.rb
@@ -25,6 +25,7 @@ describe TxghQueue::WebhookEndpoints, auto_configure: true do
 
       header('Date', date_str)
       header('X-Tx-Url', 'http://example.org/transifex')
+      header('Content-Type', 'application/json')
 
       header(
         TxghServer::TransifexRequestAuth::TRANSIFEX_HEADER,

--- a/server/History.txt
+++ b/server/History.txt
@@ -1,3 +1,6 @@
+== 3.1.0
+* Support both application/json and application/x-www-form-encoded payloads for Transifex webhooks.
+
 == 3.0.0
 * Conform to new Transifex auth strategy they didn't tell anybody about.
 

--- a/server/lib/txgh-server/version.rb
+++ b/server/lib/txgh-server/version.rb
@@ -1,3 +1,3 @@
 module TxghServer
-  VERSION = '3.0.0'
+  VERSION = '3.1.0'
 end

--- a/server/lib/txgh-server/webhooks/transifex/request_handler.rb
+++ b/server/lib/txgh-server/webhooks/transifex/request_handler.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'uri'
 
 module TxghServer
   module Webhooks
@@ -92,7 +93,12 @@ module TxghServer
 
         def payload
           @payload ||= Txgh::Utils.deep_symbolize_keys(
-            JSON.parse(raw_payload)
+            case request.env['CONTENT_TYPE']
+              when 'application/json'
+                JSON.parse(raw_payload)
+              else
+                Hash[URI.decode_www_form(raw_payload)]
+            end
           )
         end
 

--- a/server/spec/application_spec.rb
+++ b/server/spec/application_spec.rb
@@ -140,6 +140,8 @@ describe TxghServer::WebhookEndpoints do
     let(:payload) { params.to_json }
 
     before(:each) do
+      header('Content-Type', 'application/json')
+
       allow(TxghServer::Webhooks::Transifex::HookHandler).to(
         receive(:new) do |options|
           expect(options[:project].name).to eq(project_name)

--- a/server/spec/integration/hooks_spec.rb
+++ b/server/spec/integration/hooks_spec.rb
@@ -66,6 +66,8 @@ describe 'hook integration tests', integration: true do
   end
 
   before(:each) do
+    header('Content-Type', 'application/json')
+
     allow(Txgh::Config::KeyManager).to(
       receive(:raw_config).and_return("raw://#{YAML.dump(base_config)}")
     )


### PR DESCRIPTION
https://rollbar.com/lumoslabs/txgh/items/264/

A little while ago Transifex converted their webhook format from application/x-www-form-encoded to application/json. I wasn't aware of the change (because they never announced it), but immediately updated Txgh to handle the new JSON payloads. I recently discovered however that only _new_ webhooks created after a certain date will be sent a JSON payload, while old ones continue to receive form encoded payloads. We should support both.

@lumoslabs/platform 